### PR TITLE
STACK-15 Date Component Formatter Options extension

### DIFF
--- a/libs/stack-ui/.storybook/preview.js
+++ b/libs/stack-ui/.storybook/preview.js
@@ -2,7 +2,7 @@
 
 import '../src/tailwind.css'; // replace with the name of your tailwind css file
 import React, { Suspense } from 'react'
-import { OverlayProvider } from 'react-aria'
+import { I18nProvider, OverlayProvider } from 'react-aria'
 import { useGlobals } from '@storybook/client-api'
 import BaseThemeProvider from '../src/theme'
 
@@ -39,11 +39,13 @@ export const decorators = [
           `}
         </style>
           <BaseThemeProvider>
-            <OverlayProvider>
-              <Suspense fallback={<div>Loading... </div>}>
-                <Story />
-              </Suspense>
-            </OverlayProvider>
+            <I18nProvider locale={locale}>
+              <OverlayProvider>
+                <Suspense fallback={<div>Loading... </div>}>
+                  <Story />
+                </Suspense>
+              </OverlayProvider>
+            </I18nProvider>
           </BaseThemeProvider>
       </>
     )

--- a/libs/stack-ui/src/components/Date/date.stories.mdx
+++ b/libs/stack-ui/src/components/Date/date.stories.mdx
@@ -28,7 +28,7 @@ The language is handled by the `I18nProvider` of `react-aria`.
         year: 'numeric',
       },
       tokens: {
-        variant: 'p',
+        size: 'paragraph',
       },
     }}
   >
@@ -47,7 +47,7 @@ The language is handled by the `I18nProvider` of `react-aria`.
         year: 'numeric',
       },
       tokens: {
-        variant: 'p',
+        size: 'paragraph',
       },
     }}
   >

--- a/libs/stack-ui/src/components/Date/date.stories.mdx
+++ b/libs/stack-ui/src/components/Date/date.stories.mdx
@@ -9,14 +9,18 @@ export const Template = (args) => <Date {...args} />
 
 # Date
 
-Date component. Must pass a valid ISO `date`. You can also pass `dateFormat` to change the format, e.g. `MMM dd, yyyy` and `locale` to display the date in a different locale.
+Date component. Must pass a valid ISO `date`. You can also pass an object `dateFormatterOptions` to change the format, e.g. `MMM dd, yyyy` and `locale` to display the date in a different locale.
 
 <Canvas>
   <Story
     name="Short"
     args={{
       date: '2021-12-31T00:01:00-0500',
-      dateFormat: 'short',
+      dateFormatterOptions: {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      },
       tokens: {
         variant: 'p',
       },
@@ -31,7 +35,11 @@ Date component. Must pass a valid ISO `date`. You can also pass `dateFormat` to 
     name="Long"
     args={{
       date: '2021-12-31T00:01:00-0500',
-      dateFormat: 'long',
+      dateFormatterOptions: {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      },
     }}
   >
     {Template.bind({})}
@@ -43,8 +51,45 @@ Date component. Must pass a valid ISO `date`. You can also pass `dateFormat` to 
     name="Time with h4 style"
     args={{
       date: '2021-12-31T00:01:00-0500',
-      dateFormat: 'long',
-      variant: 'h4',
+      dateFormatterOptions: {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      },
+      tokens: {
+        size: 'h4',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Month and Day only"
+    args={{
+      date: '2021-12-31T00:01:00-0500',
+      dateFormatterOptions: {
+        month: 'long',
+        day: 'numeric',
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="2 digits"
+    args={{
+      date: '2021-12-31T00:01:00-0500',
+      dateFormatterOptions: {
+        month: '2-digit',
+        day: '2-digit',
+        year: '2-digit',
+      },
     }}
   >
     {Template.bind({})}

--- a/libs/stack-ui/src/components/Date/date.stories.mdx
+++ b/libs/stack-ui/src/components/Date/date.stories.mdx
@@ -1,15 +1,40 @@
 {/* Date.stories.mdx */}
-
+import { I18nProvider } from 'react-aria'
 import { Canvas, Meta, Story } from '@storybook/addon-docs'
 import Date from './index'
 
 <Meta title="BASE COMPONENTS/Date" component={Date} />
 
 export const Template = (args) => <Date {...args} />
+export const FrenchTemplate = (args) => (
+  <I18nProvider locale="fr-FR">
+    <Date {...args} />
+  </I18nProvider>
+)
 
 # Date
 
-Date component. Must pass a valid ISO `date`. You can also pass an object `dateFormatterOptions` to change the format, e.g. `MMM dd, yyyy` and `locale` to display the date in a different locale.
+Date component. Must pass a valid ISO `date`. You can also pass an object `dateFormatterOptions` to change the format, e.g. `MMM dd, yyyy` or `MM/DD/YY`.
+The language is handled by the `I18nProvider` of `react-aria`.
+
+<Canvas>
+  <Story
+    name="Different Language"
+    args={{
+      date: '2021-12-31T00:01:00-0500',
+      dateFormatterOptions: {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      },
+      tokens: {
+        variant: 'p',
+      },
+    }}
+  >
+    {FrenchTemplate.bind({})}
+  </Story>
+</Canvas>
 
 <Canvas>
   <Story

--- a/libs/stack-ui/src/components/Date/index.tsx
+++ b/libs/stack-ui/src/components/Date/index.tsx
@@ -10,7 +10,7 @@ const DateComponent = (props: TDateProps) => {
     date,
     tokens,
     customTheme,
-    dateFormat = 'long',
+    dateFormatterOptions = { month: 'long', day: 'numeric', year: 'numeric' },
     themeName = 'typography',
     ...rest
   } = props
@@ -18,11 +18,7 @@ const DateComponent = (props: TDateProps) => {
 
   const parsedDate = new Date(date)
 
-  const formatter = useDateFormatter({
-    month: dateFormat,
-    day: 'numeric',
-    year: 'numeric',
-  })
+  const formatter = useDateFormatter(dateFormatterOptions)
 
   const formattedDate = formatter.format(parsedDate)
   const theme = useThemeContext(themeName, tokens, customTheme)

--- a/libs/stack-ui/src/components/Date/interface.ts
+++ b/libs/stack-ui/src/components/Date/interface.ts
@@ -1,8 +1,7 @@
+import type { DateFormatterOptions } from 'react-aria'
 import type { TDefaultComponent } from '../../types/components'
-
-export type DateFormaTToken = 'short' | 'long'
 
 export interface TDateProps extends TDefaultComponent {
   date: string
-  dateFormat?: DateFormaTToken
+  dateFormatterOptions?: DateFormatterOptions
 }


### PR DESCRIPTION
### Requirements
- [x] Create prop `formatterOptions` extending the `useDateFormatter` options interface for Date Component to decide what type of format we want for the date
- [x] Connect the prop and keep the current hardcoded options as the default if no options are defined
- [x] Remove `dateFormat` prop (will be replaced by `formatterOptions`)

### Where to test 
Storybook