### PR TITLE
feat: extended svgprops for icon component

### DIFF
--- a/libs/stack-ui/src/components/Icon/interface.ts
+++ b/libs/stack-ui/src/components/Icon/interface.ts
@@ -1,7 +1,8 @@
 import type React from 'react'
+import type { SVGProps } from 'react'
 import type { TDefaultComponent } from '../../types/components'
 
-export interface TIconProps extends TDefaultComponent {
+export interface TIconProps extends TDefaultComponent, SVGProps<SVGSVGElement> {
   icon?: string | React.ReactNode
   children?: React.ReactNode
 }


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-16

### Requirements
- [x] Make TIconProps extend SVGProps<SVGSVGElement>
- [x] Add prop customPath for a custom brand path for icons or add iconComponent prop where you pass directly the svg you want to render inside the Icon (this one was already done since the icon can be a string or a ReactNode)
- [x] Build must pass
- [x] Lint must pass

