### PR TITLE
fix: return value of useThemeContext can be either string of undefined

### DIFF
--- a/libs/stack-ui/src/providers/Theme/hooks.ts
+++ b/libs/stack-ui/src/providers/Theme/hooks.ts
@@ -14,6 +14,9 @@ const useThemeContext = (func?: string | null, props: TToken = {}, customTheme: 
       }
     }
   }
+  if (!customTheme) {
+    return undefined
+  }
   return customTheme
 }
 


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-21

### Requirements
- [x] Build passes
- [x] Lint passes
- [x] Change return value of useThemeContext from null to undefined when there is nothing to pass

### How to test
Build stack-ui