### PR TITLE
STACK-28-Component-TextArea-should-have-both-a-wrapper-and-a-container

### DIFF
--- a/libs/stack-ui/src/components/fields/TextArea/index.tsx
+++ b/libs/stack-ui/src/components/fields/TextArea/index.tsx
@@ -24,30 +24,35 @@ const TextArea = (props: TTextAreaProps) => {
   } = props
   const ref = useRef<HTMLTextAreaElement | null>(null)
 
+  const wrapper = useThemeContext(`${themeName}.wrapper`, tokens, customTheme)
+  const input = useThemeContext(`${themeName}.input`, tokens, customTheme)
   const container = useThemeContext(`${themeName}.container`, tokens, customTheme)
-  const input = useThemeContext(`${themeName}.input`, { ...tokens, disabled, isError }, customTheme)
 
   return (
-    <div className={container}>
-      <FocusRing focusRingClass="focus-ring">
-        <textarea
-          ref={(e) => {
-            fieldRef?.(e)
-            ref.current = e
-          }}
-          className={input}
-          placeholder={placeholder}
-          disabled={disabled}
-          required={required}
-          id={id}
-          name={name}
-          aria-label={ariaLabel}
-          aria-labelledby={id}
-          value={value}
-          onBlur={onBlur}
-          onChange={onChange}
-        />
-      </FocusRing>
+    <div>
+      <div className={wrapper} aria-disabled={disabled}>
+        <div className={container}>
+          <FocusRing focusRingClass="focus-ring">
+            <textarea
+              ref={(e) => {
+                fieldRef?.(e)
+                ref.current = e
+              }}
+              className={input}
+              placeholder={placeholder}
+              disabled={disabled}
+              required={required}
+              id={id}
+              name={name}
+              aria-label={ariaLabel}
+              aria-labelledby={id}
+              value={value}
+              onBlur={onBlur}
+              onChange={onChange}
+            />
+          </FocusRing>
+        </div>
+      </div>
       {isError && errorMessage && (
         <Typography themeName={`${themeName}.errorMessage`} tokens={{ ...tokens, disabled, isError }}>
           {errorMessage}

--- a/libs/stack-ui/src/theme/index.tsx
+++ b/libs/stack-ui/src/theme/index.tsx
@@ -113,9 +113,11 @@ const BaseTheme = makeTheme({
     li: () => 'transition w-full',
   },
   textarea: {
-    container: () => 'flex flex-col',
+    wrapper: () => 'flex flex-col',
+    container: () => 'flex items-center gap-4',
     label: () => 'text-gray-3 px-6',
     input: (props) => textArea(props),
+    errorMessage: (props) => typography({ ...props, size: 'footnotes', isError: true }),
   },
   textInput: {
     wrapper: () =>


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-28

### Requirements
- [x] Rename current `container` to `wrapper`
- [x] Wrap the text area component in a new `container`
- [x] Style appropriately 
- [x] Build passes
- [x] Lint passes

### Testing
Storybook