### PR TITLE
STACK-29-BoxWithForwardRef-doesn-t-get-exported 

### DIFF
--- a/libs/stack-ui/src/index.ts
+++ b/libs/stack-ui/src/index.ts
@@ -14,7 +14,7 @@ export { default as Checkbox } from './components/fields/Checkbox'
 export { default as TextArea } from './components/fields/TextArea'
 export { default as TextInputField, ReactHookFormInput } from './components/fields/TextInputField'
 export { default as DatePicker } from './components/fields/DatePicker'
-export { default as Box } from './components/Box'
+export { default as Box, BoxWithForwardRef } from './components/Box'
 export { default as Calendar } from './components/Calendar'
 export { default as Modal } from './components/Modal'
 


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-29

### Requirements
- [x] BoxWithForwardRef component gets exported from the stack