### PR TITLE
Stack 43 component popover s popover is unstylable

### DIFF
--- a/libs/stack-ui/src/components/Popover/index.tsx
+++ b/libs/stack-ui/src/components/Popover/index.tsx
@@ -47,7 +47,7 @@ const Popover = React.forwardRef((props: IPopoverProps, ref: React.Ref<HTMLEleme
   return (
     <FocusScope autoFocus restoreFocus contain>
       <BoxWithForwardRef
-        className={theme}
+        customTheme={theme}
         {...mergeProps(overlayProps, modalProps, dialogProps)}
         ref={ref}
         {...positionProps}

--- a/libs/stack-ui/src/theme/index.tsx
+++ b/libs/stack-ui/src/theme/index.tsx
@@ -83,7 +83,7 @@ const BaseTheme = makeTheme({
   },
   popover: {
     button: (props) => button(props),
-    popover: () => 'border-2 text-black p-4',
+    popover: () => 'border-2 text-black p-4 bg-gray-300',
   },
   typography: (props) => typography(props),
   button: (props) => button(props),


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-43

## Requirements
- [x] Popover's popover component uses `customTheme` instead of `className`

## Testing
Storybook popover component should have a gray background