### PR TITLE
STACK 46 share button reformat

### DIFF
--- a/libs/stack-ui/src/components/ShareButton/index.tsx
+++ b/libs/stack-ui/src/components/ShareButton/index.tsx
@@ -19,6 +19,7 @@ export const IconsContainer = (props: TIconsContainerProps) => {
       setIsOpen(false)
     }
     const { listDirection } = tokens ?? {}
+
     if (listDirection === 'row') {
       if (e.key === 'ArrowRight') {
         focusManager.focusNext({ wrap: true })
@@ -89,21 +90,21 @@ const ShareButton = (props: TShareButtonProps) => {
   }
 
   return (
-    <div className={containerTheme}>
-      <ButtonWithForwardRef
-        themeName={`${themeName}.button`}
-        tokens={{ ...tokens, isOpen }}
-        aria-label={ariaLabel}
-        aria-haspopup="listbox"
-        aria-expanded={isOpen ? 'true' : 'false'}
-        aria-controls="share-buttons"
-        handlePress={handleClick}
-        {...rest}
-      >
-        <Icon themeName={`${themeName}.icon`} icon={icon ?? 'Share'} />
-      </ButtonWithForwardRef>
-      {isOpen && (
-        <FocusScope autoFocus restoreFocus contain>
+    <FocusScope autoFocus restoreFocus contain={isOpen}>
+      <div className={containerTheme}>
+        <ButtonWithForwardRef
+          themeName={`${themeName}.button`}
+          tokens={{ ...tokens, isOpen }}
+          aria-label={ariaLabel}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen ? 'true' : 'false'}
+          aria-controls="share-buttons"
+          handlePress={handleClick}
+          {...rest}
+        >
+          <Icon themeName={`${themeName}.icon`} icon={icon ?? 'Share'} />
+        </ButtonWithForwardRef>
+        {isOpen && (
           <IconsContainer
             id={id}
             sharingLinksList={sharingLinksList}
@@ -114,9 +115,9 @@ const ShareButton = (props: TShareButtonProps) => {
             customTheme={customTheme}
             tokens={tokens}
           />
-        </FocusScope>
-      )}
-    </div>
+        )}
+      </div>
+    </FocusScope>
   )
 }
 export default ShareButton

--- a/libs/stack-ui/src/components/ShareButton/index.tsx
+++ b/libs/stack-ui/src/components/ShareButton/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { PressEvent } from '@react-types/shared'
 import React, { useState } from 'react'
 import { FocusScope, useFocusManager } from 'react-aria'
 import useThemeContext from '../../providers/Theme/hooks'
@@ -85,13 +86,61 @@ const ShareButton = (props: TShareButtonProps) => {
 
   const containerTheme = useThemeContext(`${themeName}.container`, tokens, customTheme)
 
-  const handleClick = () => {
+  const handleClick = (e: PressEvent) => {
     setIsOpen(!isOpen)
+    if (isOpen) {
+      return
+    }
+    setTimeout(() => {
+      const firstOption = e.target.parentElement?.lastChild?.firstChild as HTMLElement
+      firstOption?.focus()
+    })
+  }
+
+  const handleKeyDown: React.KeyboardEventHandler = (e) => {
+    const openShareButton = e.currentTarget.firstChild as HTMLElement
+    const listBox = e.currentTarget.lastChild as HTMLElement
+    const firstOption = listBox.firstChild as HTMLElement
+
+    const lastOption = listBox.lastChild as HTMLElement
+
+    const { listDirection } = tokens ?? {}
+
+    if (listDirection === 'row') {
+      if (e.key === 'ArrowRight' && e.target === openShareButton) {
+        firstOption?.focus()
+        e.preventDefault()
+      }
+      if (e.key === 'ArrowLeft' && e.target === openShareButton) {
+        lastOption.focus()
+        e.preventDefault()
+      }
+    }
+
+    if (listDirection === 'column') {
+      if (e.key === 'ArrowDown' && e.target === openShareButton) {
+        firstOption?.focus()
+        e.preventDefault()
+      }
+      if (e.key === 'ArrowUp' && e.target === openShareButton) {
+        lastOption.focus()
+        e.preventDefault()
+      }
+    }
+
+    if (e.key === 'Escape') {
+      setIsOpen(false)
+      openShareButton?.focus()
+    }
+    if (document.activeElement === listBox) {
+      openShareButton?.focus()
+    }
   }
 
   return (
     <FocusScope autoFocus restoreFocus contain={isOpen}>
-      <div className={containerTheme}>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div className={containerTheme} onKeyDown={handleKeyDown}>
         <ButtonWithForwardRef
           themeName={`${themeName}.button`}
           tokens={{ ...tokens, isOpen }}

--- a/libs/stack-ui/src/storybook/ShareButtonExample/index.tsx
+++ b/libs/stack-ui/src/storybook/ShareButtonExample/index.tsx
@@ -1,15 +1,18 @@
 import { useCopyToClipboard } from 'usehooks-ts'
 import LinkedIn from '../../components/icons/LinkedIn'
 import ShareButton from '../../components/ShareButton'
+import type { TShareButtonProps } from '../../components/ShareButton/interface'
 import Typography from '../../components/Typography'
 
-const ShareButtonExample = () => {
+const ShareButtonExample = (props: TShareButtonProps) => {
+  const { tokens } = props
   const [value, copy] = useCopyToClipboard()
   return (
     <>
       <ShareButton
         id="share"
         ariaLabel="Share"
+        tokens={tokens}
         sharingLinksList={[
           {
             ariaLabel: 'Share on Facebook',


### PR DESCRIPTION
### Tasks
- [x] added the listbox button opener in the focus scope
- [x] When opening the listbox, the first focus should go on the first item
- [x] The listbox should be naviguable with the correct arrow keys depending on the orientation 

### Linked task
This task has already been done in the context of The Lede
https://github.com/OKAMca/bellmedia-thelede-nextjs/pull/73

The linked task has been resolved in this PR : https://okamca.atlassian.net/jira/software/projects/STACK/issues/STACK-44