### PR TITLE
STACK-49-Component-Checkbox-uses-label-theme-twice

### DIFF
--- a/libs/stack-ui/src/components/fields/Checkbox/Checkbox.stories.mdx
+++ b/libs/stack-ui/src/components/fields/Checkbox/Checkbox.stories.mdx
@@ -19,6 +19,7 @@ export const Template = (args) => <Checkbox {...args} />
 
 Checkbox component.
 
+## Default
 <Canvas>
   <Story
     name="Default"
@@ -30,6 +31,22 @@ Checkbox component.
   </Story>
 </Canvas>
 
+## Color variant
+<Canvas>
+  <Story
+    name="Gray"
+    args={{
+      id: 'checkbox-8',
+      tokens: {
+        color: 'gray'
+      }
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## With icon
 <Canvas>
   <Story 
     name="With icon"
@@ -42,6 +59,7 @@ Checkbox component.
   </Story>
 </Canvas>
 
+## Disabled
 <Canvas>
   <Story
     name="Disabled"
@@ -54,6 +72,7 @@ Checkbox component.
   </Story>
 </Canvas>
 
+## Error
 <Canvas>
   <Story
     name="Error"

--- a/libs/stack-ui/src/components/fields/Checkbox/index.tsx
+++ b/libs/stack-ui/src/components/fields/Checkbox/index.tsx
@@ -45,7 +45,7 @@ const Checkbox = (props: TCheckboxProps) => {
           <div className={checkBoxTheme} aria-checked={isSelected} role="checkbox" aria-labelledby={id}>
             <div className={checkMarkTheme}>{icon && <Icon icon={icon} customTheme={checkMarkIconTheme} />}</div>
           </div>
-          <Typography themeName={`${themeName}.label`}>{label}</Typography>
+          <Typography>{label}</Typography>
         </label>
       </FocusRing>
       {isError && errorMessage && (

--- a/libs/stack-ui/src/theme/Checkbox/index.ts
+++ b/libs/stack-ui/src/theme/Checkbox/index.ts
@@ -1,11 +1,18 @@
 import { tv } from 'tailwind-variants'
 
 export const checkboxLabel = tv({
-  base: `text-gray-2 flex flex-row items-start hover:cursor-pointer focus-ring-black`,
+  base: `flex flex-row items-start hover:cursor-pointer focus-ring-black`,
   variants: {
+    color: {
+      gray: 'text-gray-300',
+      black: 'text-black',
+    },
     isDisabled: {
       true: 'text-gray-6',
     },
+  },
+  defaultVariants: {
+    color: 'black',
   },
 })
 


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-49

## Requirements
- [ ] Checkbox label has working variants

## Testing
Storybook, check the 'color variant' story of the checkbox. Should have a different text color

