### PR TITLE
Stack 104 accordion should take component icon have a default opened state prop

### DIFF
--- a/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
@@ -18,7 +18,7 @@ import CloseBtn from '../icons/CloseBtn'
       description: 'Used for accessibility',
     },
     icon: {
-      description: 'Takes in the name of an Icon inside the available icons folder',
+      description: 'Takes in the name of an Icon inside the available icons folder or a component icon',
       defaultValue: {
         summary: 'ArrowRight',
       },

--- a/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
@@ -92,3 +92,18 @@ export const Template = (args) => (
     {Template.bind({})}
   </Story>
 </Canvas>
+### Default opened accordion
+<Canvas>
+  <Story
+    name="Default opened"
+    args={{
+      id: 'accordion',
+      tokens: {
+        textAlign: 'left',
+      },
+      defaultIsOpen: true,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs'
 import { ArgTypes } from '@storybook/blocks'
 import Accordion from './'
+import CloseBtn from '../icons/CloseBtn'
 
 <Meta
   title="Base Components/Accordion"
@@ -102,6 +103,7 @@ export const Template = (args) => (
         textAlign: 'left',
       },
       defaultIsOpen: true,
+      icon: <CloseBtn />,
     }}
   >
     {Template.bind({})}

--- a/libs/stack/stack-ui/src/components/Accordion/index.tsx
+++ b/libs/stack/stack-ui/src/components/Accordion/index.tsx
@@ -7,9 +7,20 @@ import Icon from '../Icon'
 import type { TAccordionProps } from './interface'
 
 const Accordion = (props: TAccordionProps) => {
-  const { customTheme, themeName = 'accordion', id, tokens, title, ariaLabel, onClick, icon, children } = props
+  const {
+    customTheme,
+    themeName = 'accordion',
+    id,
+    tokens,
+    title,
+    ariaLabel,
+    onClick,
+    icon,
+    children,
+    defaultIsOpen = false,
+  } = props
 
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(defaultIsOpen)
 
   const containerTheme = useThemeContext(`${themeName}.container`, { ...tokens, isOpen }, customTheme)
   const titleTheme = useThemeContext(`${themeName}.title`, { ...tokens, isOpen }, customTheme)

--- a/libs/stack/stack-ui/src/components/Accordion/interface.ts
+++ b/libs/stack/stack-ui/src/components/Accordion/interface.ts
@@ -5,10 +5,11 @@ import type { TDefaultComponent } from '../../types/components'
 export interface TAccordionProps extends TDefaultComponent<TAccordionTokens> {
   id: string
   title: string
-  icon?: string
+  icon?: React.ReactNode
   ariaLabel: string
   children: React.ReactNode
   onClick?: (isOpen: boolean) => void
+  defaultIsOpen?: boolean
 }
 
 interface TAccordionTokens extends TToken {


### PR DESCRIPTION
https://okamca.atlassian.net/browse/STACK-104

## Requirements

- [x] Default opened prop should allow for a default opened state accordion
- [x] Icon prop should be able to take in ReactNode type