### PR TITLE
chore(directus-node): try to publish the package

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -84,3 +84,30 @@ jobs:
         run: yarn publish-stack
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish-directus-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@okam'
+
+      - name: Configure Git
+        shell: bash
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install dependencies
+        shell: bash
+        run: yarn install
+
+      - name: Build Directus Node
+        run: yarn build-directus-node
+
+      - name: Publish Directus Node Package
+        run: yarn publish-directus-node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/libs/directus/directus-node/package.json
+++ b/libs/directus/directus-node/package.json
@@ -1,4 +1,18 @@
 {
   "name": "@okam/directus-node",
-  "version": "0.0.1"
+  "main": "./index.js",
+  "version": "0.0.1",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js"
+    }
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "url": "https://github.com/OKAMca/stack.git"
+  }
 }

--- a/libs/directus/directus-node/package.json
+++ b/libs/directus/directus-node/package.json
@@ -3,12 +3,6 @@
   "main": "./index.js",
   "version": "0.0.1",
   "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
-    }
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "storybook": "nx run stack-ui:storybook",
     "build-stack": "yarn nx run stack-ui:build:production",
     "build-core": "yarn nx run core-lib:build:production",
+    "build-directus-node": "yarn nx run directus-node:build:production",
     "publish-stack": "yarn npm publish --access public dist/libs/stack/stack-ui",
     "publish-core": "yarn npm publish --access public dist/libs/stack/core-lib",
+    "publish-directus-node": "yarn npm publish --access public dist/libs/directus/directus-node",
     "dev": "nx serve demo",
     "build": "nx build demo",
     "postinstall": "is-ci || yarn husky install"


### PR DESCRIPTION
Missing .mjs output like the other package, but vite is not used in this package?