### PR TITLE
fix(textinputfield): adding inputProps type casting

### DIFF
--- a/libs/stack/stack-ui/src/components/fields/TextInputField/index.tsx
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/index.tsx
@@ -8,7 +8,7 @@ import { get, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import useThemeContext from '../../../providers/Theme/hooks'
 import Typography from '../../Typography'
-import type { TTextInputProps } from './interface'
+import type { TTextInputProps, TUseTextFieldInputProps } from './interface'
 
 const TextInputField = (props: TTextInputProps) => {
   const {
@@ -29,6 +29,8 @@ const TextInputField = (props: TTextInputProps) => {
     customTheme,
   } = props
   const ref = useRef<HTMLInputElement | null>(null)
+  // inputProps will be cast to TUseTextFieldInputProps
+  // so you should only use useTextField<'input'>
   const { errorMessageProps, inputProps, labelProps } = useTextField<'input'>(props, ref)
 
   const inputTokens = { ...tokens, isDisabled: disabled, isError: errorMessage != null }
@@ -52,7 +54,7 @@ const TextInputField = (props: TTextInputProps) => {
             {children}
 
             <input
-              {...(inputProps as object)}
+              {...(inputProps as TUseTextFieldInputProps)}
               className={input}
               disabled={disabled}
               required={required}

--- a/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
@@ -1,3 +1,4 @@
+import type { InputHTMLAttributes } from 'react'
 import type { AriaTextFieldProps } from 'react-aria'
 import type { RefCallBack } from 'react-hook-form'
 import type { TDefaultComponent, TReactHookForm } from '../../../types/components'
@@ -18,3 +19,6 @@ export interface TTextInputStyle extends TDefaultComponent {
   isError?: boolean
   errorMessage?: string
 }
+
+// @see https://react-spectrum.adobe.com/react-aria/useTextField.html
+export type TUseTextFieldInputProps = InputHTMLAttributes<HTMLInputElement>


### PR DESCRIPTION
Note that the type is TextFieldAria<'input'>['inputProps'] (converted as "never") because of `ReactDOM[K] extends DOMFactory<infer T, any> ? T : never;`  (from react)

But the online documentation specified inputProps as InputHTMLAttributes<HTMLInputElement>  where InputHTMLAttributes is from react and HTMLInputElement from global (dom)