### PR TITLE
fix: Stack-143 accordion accordion items can t define their own

### DIFF
--- a/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Accordion/accordion.stories.mdx
@@ -131,7 +131,11 @@ export const TemplateControlledState = (args) => {
         textAlign: 'center',
       },
       children: [
-        <AccordionItem key="item-1" title="This is an accordion" onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}>
+        <AccordionItem 
+          key="item-1" 
+          title="This is an accordion" 
+          onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}
+        >
           BODY TEXT: Is not the best kind of originality that which comes after a sound apprenticeship? That which shall
           prove to be the blending of a firm conception of, “useful precedent” and the progressive tendencies of an able
           mind.
@@ -155,7 +159,12 @@ export const TemplateControlledState = (args) => {
       },
       icon: <CloseBtn />,
       children: [
-        <AccordionItem key="item-1" title="This is an accordion" defaultOpen onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}>
+        <AccordionItem 
+          key="item-1" 
+          title="This is an accordion" 
+          defaultOpen 
+          onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}
+        >
           BODY TEXT: Is not the best kind of originality that which comes after a sound apprenticeship? That which shall
           prove to be the blending of a firm conception of, “useful precedent” and the progressive tendencies of an able
           mind.
@@ -179,11 +188,23 @@ export const TemplateControlledState = (args) => {
       },
       icon: <CloseBtn />,
       children: [
-        <AccordionItem key="item-1" title="This is an accordion" onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}>
+        <AccordionItem 
+          key="item-1" 
+          title="This is an accordion" 
+          tokens={{ bgColor: 'white' }} 
+          onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}
+          icon="Plus"
+        >
           <Button>Focusable item 1</Button>
           <Button>Focusable item 2</Button>
         </AccordionItem>,
-        <AccordionItem key="item-2" title="This is an accordion 2" onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}>
+        <AccordionItem 
+          key="item-2" 
+          title="This is an accordion 2" 
+          tokens={{ bgColor: 'gray' }} 
+          onOpenChange={(isOpen) => console.log(`Open state was change to: ${isOpen}`)}
+          icon="Plus"
+        >
           <Button>Focusable item</Button>
         </AccordionItem>
       ]

--- a/libs/stack/stack-ui/src/components/Accordion/components/AriaAccordionItem.tsx
+++ b/libs/stack/stack-ui/src/components/Accordion/components/AriaAccordionItem.tsx
@@ -11,9 +11,10 @@ import Icon from '../../Icon'
 import type { TAriaAccordionItemProps } from '../interface'
 
 const AriaAccordionItem = (props: TAriaAccordionItemProps) => {
-  const { item, themeName, tokens, customTheme } = props
+  const { item, tokens, customTheme } = props
   const { props: itemProps, rendered, key } = item
-  const { icon, title, onOpenChange } = itemProps ?? {}
+  const { icon, title, onOpenChange, tokens: itemTokens, themeName: itemThemeName } = itemProps ?? {}
+  const { themeName = itemThemeName } = props
 
   const ref = useRef(null)
   const { state, TransitionAnimation = AccordionTransition } = useAccordionCtx()
@@ -25,7 +26,7 @@ const AriaAccordionItem = (props: TAriaAccordionItemProps) => {
 
   const isOpen = state.selectionManager.selectedKeys.has(key)
 
-  const accordionTokens = { ...tokens, isOpen }
+  const accordionItemTokens = { ...tokens, isOpen, ...itemTokens }
 
   const handlePress: TButtonProps['handlePress'] = (e) => {
     e.continuePropagation()
@@ -38,30 +39,32 @@ const AriaAccordionItem = (props: TAriaAccordionItemProps) => {
   }, [isOpen])
 
   return (
-    <Box themeName={`${themeName}.container`} tokens={accordionTokens} customTheme={customTheme}>
+    <Box themeName={`${themeName}.container`} tokens={accordionItemTokens} customTheme={customTheme}>
       <FocusRing focusRingClass="has-focus-ring">
         <ButtonWithForwardRef
           {...buttonProps}
           handlePress={handlePress}
           ref={ref}
           themeName={`${themeName}.button`}
-          tokens={accordionTokens}
+          tokens={accordionItemTokens}
         >
-          <Box themeName={`${themeName}.title`} tokens={accordionTokens}>
+          <Box themeName={`${themeName}.title`} tokens={accordionItemTokens}>
             {title}
           </Box>
-          <Box themeName={`${themeName}.icon`} tokens={accordionTokens}>
-            <Icon icon={icon ?? 'ArrowDown'} />
-          </Box>
+          {icon && (
+            <Box themeName={`${themeName}.icon`} tokens={accordionItemTokens}>
+              <Icon icon={icon} />
+            </Box>
+          )}
         </ButtonWithForwardRef>
       </FocusRing>
       <TransitionAnimation
         isVisible={isOpen}
         themeName={`${themeName}.region`}
         {...regionProps}
-        tokens={accordionTokens}
+        tokens={accordionItemTokens}
       >
-        <Box themeName={`${themeName}.content`} tokens={accordionTokens}>
+        <Box themeName={`${themeName}.content`} tokens={accordionItemTokens}>
           <FocusScope autoFocus>{rendered}</FocusScope>
         </Box>
       </TransitionAnimation>

--- a/libs/stack/stack-ui/src/components/Accordion/interface.ts
+++ b/libs/stack/stack-ui/src/components/Accordion/interface.ts
@@ -2,10 +2,9 @@
 import type { AccordionItemAriaProps } from '@react-aria/accordion'
 import type { ComponentType, ReactElement } from 'react'
 import type { ItemProps, TreeProps } from 'react-stately'
-import type { TToken } from '../../providers/Theme/interface'
 import type { TDefaultComponent, TTransition } from '../../types/components'
 
-type TAccordionDefaultComponent = Omit<TDefaultComponent<TAccordionTokens>, 'children'>
+type TAccordionDefaultComponent = Omit<TDefaultComponent, 'children'>
 
 export interface AccordionProps extends TreeProps<TAccordionItemProps> {
   children: ReactElement<TAccordionItemProps> | ReactElement<TAccordionItemProps>[]
@@ -18,7 +17,7 @@ export interface TAccordionProps extends TAccordionDefaultComponent, AccordionPr
 
 export interface TAccordionItemProps extends ItemProps<TAccordionItemProps>, TAccordionDefaultComponent {
   icon?: React.ReactNode
-  onOpenChange: (isOpen: boolean) => void
+  onOpenChange?: (isOpen: boolean) => void
   defaultOpen?: boolean
   isOpen?: boolean
 }
@@ -29,8 +28,3 @@ export type TAriaAccordionItemProps = TAccordionDefaultComponent &
       props?: TAccordionItemProps
     }
   }
-
-interface TAccordionTokens extends TToken {
-  titleBold: boolean
-  textAlign: 'center' | 'left'
-}

--- a/libs/stack/stack-ui/src/theme/Accordion/index.tsx
+++ b/libs/stack/stack-ui/src/theme/Accordion/index.tsx
@@ -25,6 +25,15 @@ export const accordionButton = tv({
       center: 'grid-cols-[3rem_1fr_3rem] pl-0 sm:pl-0',
       left: 'grid-cols-[1fr_3rem]',
     },
+    bgColor: {
+      gray: 'bg-gray-300',
+      white: 'bg-white',
+    },
+  },
+  defaultVariants: {
+    titleBold: false,
+    textAlign: 'left',
+    bgColor: 'white',
   },
 })
 


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-143

## Implementation details
- [x] onOpenChange should not be required
- [x] Accordion items should use their and the accordion's tokens
- [x] Accordion items should prioritize their own theme name, only fallback to the accordion's

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Storybook
- Some accordion stories should have custom accordion items tokens
