### PR TITLE
refactor: add target link attribute to wysiwyg

### DIFF
--- a/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
@@ -10,7 +10,7 @@ const WysiwygBlock = ({ content, themeName = 'wysiwyg', ...rest }: TWysiwygBlock
       dangerouslySetInnerHTML={{
         __html: DOMPurify.sanitize(content, {
           ADD_TAGS: ['iframe'],
-          ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+          ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling', 'target'],
         }),
       }}
     />

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.mdx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.mdx
@@ -1,9 +1,18 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs'
+import { ArgTypes } from '@storybook/blocks'
 import WysiwygBlock from './'
 
 <Meta
   title="BASE COMPONENTS/Wysiwyg Block"
   component={WysiwygBlock}
+  argTypes={{
+    content: {
+      description: 'Takes HTML elements in string form from the Wysiwyg block content',
+    },
+    WysiwygBlockAttributes: {
+      description: 'target, allow, allowfullscreen, frameborder, scrolling, iframe',
+    }
+  }}
   args={{
     content: '<a target="_self" href="https://www.google.com/">Link with target _self</a>',
   }}
@@ -13,19 +22,30 @@ export const Template = (args) => {
   return <WysiwygBlock {...args} />
 }
 
-# Wysiwyg Block link with target \_self
+# Wysiwyg Block
+
+#### Wysiwyg Block. Can be used in CMS to insert HTML elements as text with certain attributes (h1, h2, h3, link with target, etc.)
+
+## Props
+
+<ArgTypes />
+
+## Showcase
+
+### Wysiwyg Block link with target \_self
+
 
 <Canvas>
   <Story name="Link with target _self">{Template.bind({})}</Story>
 </Canvas>
 
-# Wysiwyg Block link with target \_blank
+### Wysiwyg Block link with target \_blank
 
 <Canvas>
   <Story
     name="Link with target blank"
     args={{
-      content: '<a target="_blank" href="https://www.google.com/">Link with target _blank</a>'
+      content: '<a target="_blank" href="https://www.google.com/">Link with target _blank</a>',
     }}
   >
     {Template.bind({})}

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.mdx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.mdx
@@ -1,0 +1,33 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs'
+import WysiwygBlock from './'
+
+<Meta
+  title="BASE COMPONENTS/Wysiwyg Block"
+  component={WysiwygBlock}
+  args={{
+    content: '<a target="_self" href="https://www.google.com/">Link with target _self</a>',
+  }}
+/>
+
+export const Template = (args) => {
+  return <WysiwygBlock {...args} />
+}
+
+# Wysiwyg Block link with target \_self
+
+<Canvas>
+  <Story name="Link with target _self">{Template.bind({})}</Story>
+</Canvas>
+
+# Wysiwyg Block link with target \_blank
+
+<Canvas>
+  <Story
+    name="Link with target blank"
+    args={{
+      content: '<a target="_blank" href="https://www.google.com/">Link with target _blank</a>'
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-142
## Implementation details
- [ ] Wysiwyg block should accept `target` attribute
- [ ] Should have a story displaying the target attribute functionality with the Wysiwyg block

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- You can test this PR by running the `yarn storybook` CLI command and you should see the `Wysiwyg block` story under `Base Components`
