### PR TITLE
STACK-115-Text-input-Accessibility-Should-not-define-its-own-aria-labelledby

### DIFF
--- a/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
@@ -1,23 +1,29 @@
 import type { InputHTMLAttributes } from 'react'
-import type { AriaTextFieldProps } from 'react-aria'
+import type { AriaTextFieldOptions } from 'react-aria'
 import type { RefCallBack } from 'react-hook-form'
 import type { TDefaultComponent, TReactHookForm } from '../../../types/components'
 
-export type TFieldReactHookForm = TReactHookForm & TDefaultComponent
+export type TFieldReactHookForm = TDefaultComponent & TReactHookForm
 
-export interface TTextInputProps extends TFieldReactHookForm, Omit<AriaTextFieldProps, 'onBlur' | 'onChange'> {
+export interface TTextInputProps
+  extends TFieldReactHookForm,
+    Omit<AriaTextFieldOptions<'input'>, 'onChange' | 'onBlur'> {
   name: string
-  required?: boolean
-  disabled?: boolean
-  errorMessage?: string
-  isError?: boolean
   ariaLabel?: string
-  fieldRef?: RefCallBack
-}
-
-export interface TTextInputStyle extends TDefaultComponent {
-  isError?: boolean
   errorMessage?: string
+  fieldRef?: RefCallBack
+  /**
+   * @deprecated use isRequired instead
+   */
+  required?: boolean
+  /**
+   * @deprecated use isDisabled instead
+   */
+  disabled?: boolean
+  /**
+   * @deprecated depends on errorMEssage
+   */
+  isError?: boolean
 }
 
 // @see https://react-spectrum.adobe.com/react-aria/useTextField.html

--- a/libs/stack/stack-ui/src/components/fields/TextInputField/text-input-field.stories.mdx
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/text-input-field.stories.mdx
@@ -4,26 +4,24 @@ import TextInputField from './index'
 <Meta
   title="Form/Fields/Text Input"
   component={TextInputField}
-  parameters={{
-    layout: 'fullscreen',
-  }}
   args={{
     id: '',
     label: 'First Name',
     name: 'name',
-    placeholder: 'First Name',
-    required: true,
-    disabled: false,
+    placeholder: 'Your name here',
+    isDisabled: false,
     isError: false,
     ariaLabel: 'First name',
     icon: 'ArrowRight',
+    onChange: (value) => console.log(`Value is now ${value}`),
+    onBlur: (e) => console.log(`Value was ${e.target.value} when the field was blurred`)
   }}
 />
 
 export const Template = (args) => {
   const { backgroundColor, ...rest } = args
   return (
-    <div className={`flex flex-col m-auto h-screen justify-center items-center`}>
+    <div className={`flex flex-col m-auto justify-center items-center`}>
       <TextInputField {...rest} />
     </div>
   )
@@ -32,14 +30,21 @@ export const Template = (args) => {
 # Text Input Field
 
 <Canvas>
-  <Story name="Default">{Template.bind({})}</Story>
+  <Story 
+    name="Default"
+    args={{
+      isRequired: true,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
 </Canvas>
 
 <Canvas>
   <Story
     name="Disabled"
     args={{
-      disabled: true,
+      isDisabled: true,
     }}
   >
     {Template.bind({})}

--- a/libs/stack/stack-ui/src/theme/index.tsx
+++ b/libs/stack/stack-ui/src/theme/index.tsx
@@ -162,8 +162,8 @@ const BaseTheme = makeTheme({
   },
   textInput: {
     wrapper: () =>
-      `flex flex-col rounded-md px-4 py-1 mb-3 m-0.5 border-2 aria-disabled:pointer-events-none aria-disabled:opacity-30 focus-ring-black`,
-    label: () => 'text-xs',
+      `group flex flex-col rounded-md px-4 py-1 mb-3 m-0.5 border-2 aria-disabled:pointer-events-none aria-disabled:opacity-30 focus-ring-black`,
+    label: () => 'group-has-[:required]:after:content-["_*"] group-has-[:required]:after:text-red-500 text-xs',
     container: () => 'flex items-center gap-4',
     input: () => '',
     errorMessage: (props) => typography({ ...props, size: 'footnotes', isError: true }),


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-115

## Implementation details
- [ ] required and aria-required attributes should be set on the input
- [ ] input element should not define its aria-labelledby attribute

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Storybook
