### PR TITLE
fix: aria expanded attributes not set properly on multiple items accordions

### DIFF
--- a/libs/stack/stack-ui/src/components/Accordion/components/AriaAccordionItem.tsx
+++ b/libs/stack/stack-ui/src/components/Accordion/components/AriaAccordionItem.tsx
@@ -43,6 +43,7 @@ const AriaAccordionItem = (props: TAriaAccordionItemProps) => {
       <FocusRing focusRingClass="has-focus-ring">
         <ButtonWithForwardRef
           {...buttonProps}
+          aria-expanded={isOpen}
           handlePress={handlePress}
           ref={ref}
           themeName={`${themeName}.button`}


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-158

## Implementation details
- [x] Aria-expanded attribute value should reflect the open state of the accordion

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Try in storybook to open multiple items and look if the attributes follow correctly
