### PR TITLE
fix: alerts a11y focus carousel

### DIFF
--- a/libs/stack/stack-ui/src/components/Alerts/alerts.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Alerts/alerts.stories.mdx
@@ -173,6 +173,11 @@ export const Template = (args) => (
           )
         },
         {
+          button: {
+            href: '#',
+            as: 'a',
+            children: 'Consulter toutes les alertes'
+          },
           id: '2',
           title: 'Alert 2 title',
           'aria-label': 'Alert 2 aria',

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
@@ -6,7 +6,7 @@ import Icon from '../../Icon'
 import type { TAlertsItemProps } from '../interface'
 
 const AlertsItem = (props: TAlertsItemProps) => {
-  const { title, button, content, themeName = 'alerts.item', tokens, icon, id } = props
+  const { title, button, content, themeName = 'alerts.item', tokens, icon, id, isActive } = props
 
   const titleTheme = useThemeContext(`${themeName}.title`, tokens)
 
@@ -22,7 +22,9 @@ const AlertsItem = (props: TAlertsItemProps) => {
               {title}
             </span>
           )}
-          {button && <Button themeName={`${themeName}.button`} tokens={tokens} {...button} />}
+          {button && (
+            <Button tabIndex={isActive ? 0 : -1} themeName={`${themeName}.button`} tokens={tokens} {...button} />
+          )}
           {content &&
             (React.isValidElement(content)
               ? React.cloneElement(content, { ...content.props, themeName: `${themeName}.content`, tokens })

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useSwiperSlide } from 'swiper/react'
 import useThemeContext from '../../../providers/Theme/hooks'
 import Box from '../../Box'
 import Button from '../../Button'
@@ -6,9 +7,10 @@ import Icon from '../../Icon'
 import type { TAlertsItemProps } from '../interface'
 
 const AlertsItem = (props: TAlertsItemProps) => {
-  const { title, button, content, themeName = 'alerts.item', tokens, icon, id, isActive } = props
+  const { title, button, content, themeName = 'alerts.item', tokens, icon, id } = props
 
   const titleTheme = useThemeContext(`${themeName}.title`, tokens)
+  const { isActive } = useSwiperSlide()
 
   if (!title && !button && !content && !icon) return null
 

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import * as swiperModules from 'swiper/modules'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import useThemeContext from '../../../providers/Theme/hooks'
@@ -23,7 +23,6 @@ const AlertsSwiper = (props: TAlertsProps) => {
     nextButton: NextButton = AlertsNextNavigationButton,
     ...rest
   } = props
-
   const prevButtonRef = useRef(null)
   const nextButtonRef = useRef(null)
 
@@ -46,17 +45,28 @@ const AlertsSwiper = (props: TAlertsProps) => {
 
   const hasNavigation = modules?.includes('Navigation')
 
+  const [activeIndex, setActiveIndex] = useState(0)
+
   return (
     <>
       {hasNavigation && (
         <PrevButton
           themeName={`${themeName}.navigation.button`}
-          tokens={tokens}
+          tokens={{ ...tokens, order: 'prev' }}
           ref={prevButtonRef}
           aria-label={a11y?.prevSlideMessage}
         />
       )}
+      {hasNavigation && (
+        <NextButton
+          themeName={`${themeName}.navigation.button`}
+          tokens={{ ...tokens, order: 'next' }}
+          ref={nextButtonRef}
+          aria-label={a11y?.nextSlideMessage}
+        />
+      )}
       <Swiper
+        tabIndex={0}
         {...rest}
         navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
         pagination={{
@@ -65,6 +75,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
           bulletActiveClass: paginationActiveBulletTheme,
           clickable: true,
         }}
+        onActiveIndexChange={(index) => setActiveIndex(index.activeIndex)}
         role="group"
         aria-roledescription={containerRoleDescriptionMessage ?? undefined}
         slidesPerView={slidesPerView}
@@ -78,7 +89,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
         }}
         a11y={a11y}
       >
-        {alerts.map((alert) => {
+        {alerts.map((alert, index) => {
           const { id, title, ariaLabel } = alert
 
           return (
@@ -89,19 +100,11 @@ const AlertsSwiper = (props: TAlertsProps) => {
               role={slideRole}
               aria-roledescription={itemRoleDescriptionMessage ?? undefined}
             >
-              {children({ ...alert, themeName: `${themeName}.item`, tokens })}
+              {children({ ...alert, themeName: `${themeName}.item`, tokens, isActive: index === activeIndex })}
             </SwiperSlide>
           )
         })}
       </Swiper>
-      {hasNavigation && (
-        <NextButton
-          themeName={`${themeName}.navigation.button`}
-          tokens={tokens}
-          ref={nextButtonRef}
-          aria-label={a11y?.nextSlideMessage}
-        />
-      )}
     </>
   )
 }

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -97,10 +97,14 @@ const AlertsSwiper = (props: TAlertsProps) => {
               role={slideRole}
               aria-roledescription={itemRoleDescriptionMessage ?? undefined}
             >
-              {({ isActive }) => children({ ...alert, themeName: `${themeName}.item`, tokens, isActive })}
+              {children({ ...alert, themeName: `${themeName}.item`, tokens })}
             </SwiperSlide>
           )
         })}
+        <span slot="container-start">Container Start</span>
+        <span slot="container-end">Container End</span>
+        <span slot="wrapper-start">Wrapper Start</span>
+        <span slot="wrapper-end">Wrapper End</span>
       </Swiper>
     </>
   )

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -101,10 +101,6 @@ const AlertsSwiper = (props: TAlertsProps) => {
             </SwiperSlide>
           )
         })}
-        <span slot="container-start">Container Start</span>
-        <span slot="container-end">Container End</span>
-        <span slot="wrapper-start">Wrapper Start</span>
-        <span slot="wrapper-end">Wrapper End</span>
       </Swiper>
     </>
   )

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -45,8 +45,6 @@ const AlertsSwiper = (props: TAlertsProps) => {
 
   const hasNavigation = modules?.includes('Navigation')
 
-  const [activeIndex, setActiveIndex] = useState(0)
-
   return (
     <>
       {hasNavigation && (
@@ -75,7 +73,6 @@ const AlertsSwiper = (props: TAlertsProps) => {
           bulletActiveClass: paginationActiveBulletTheme,
           clickable: true,
         }}
-        onActiveIndexChange={(index) => setActiveIndex(index.activeIndex)}
         role="group"
         aria-roledescription={containerRoleDescriptionMessage ?? undefined}
         slidesPerView={slidesPerView}
@@ -89,7 +86,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
         }}
         a11y={a11y}
       >
-        {alerts.map((alert, index) => {
+        {alerts.map((alert) => {
           const { id, title, ariaLabel } = alert
 
           return (
@@ -100,7 +97,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
               role={slideRole}
               aria-roledescription={itemRoleDescriptionMessage ?? undefined}
             >
-              {children({ ...alert, themeName: `${themeName}.item`, tokens, isActive: index === activeIndex })}
+              {({ isActive }) => children({ ...alert, themeName: `${themeName}.item`, tokens, isActive })}
             </SwiperSlide>
           )
         })}

--- a/libs/stack/stack-ui/src/components/Alerts/interface.ts
+++ b/libs/stack/stack-ui/src/components/Alerts/interface.ts
@@ -16,6 +16,7 @@ export interface TAlertsItem {
   ariaLabel?: string
   content?: React.ReactNode
   button?: TButtonProps
+  isActive?: boolean
 }
 
 export interface TAlertsComponentProps

--- a/libs/stack/stack-ui/src/components/Alerts/interface.ts
+++ b/libs/stack/stack-ui/src/components/Alerts/interface.ts
@@ -16,7 +16,6 @@ export interface TAlertsItem {
   ariaLabel?: string
   content?: React.ReactNode
   button?: TButtonProps
-  isActive?: boolean
 }
 
 export interface TAlertsComponentProps

--- a/libs/stack/stack-ui/src/theme/Alerts/index.ts
+++ b/libs/stack/stack-ui/src/theme/Alerts/index.ts
@@ -16,7 +16,7 @@ const alertsCloseBtn = tv({
 })
 
 const alertsSwiperSwiper = tv({
-  base: 'bg-color-1-300 m-2 rounded-lg',
+  base: 'bg-color-1-300 m-2 rounded-lg order-2',
 })
 
 const alertsSwiperWrapper = tv({
@@ -48,6 +48,12 @@ const alertsItemIcon = tv({
 
 const alertsNavigationButton = tv({
   extend: button,
+  variants: {
+    order: {
+      prev: 'order-1',
+      next: 'order-3',
+    },
+  },
 })
 
 const alertsPaginationWrapper = tv({


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-159

## Implementation details
- [x] Focus order should be 1. Close button 2. Prev button 3. Next button 4. Active slide
- [x] There should not be any navigation using tab between slides (navigation should only be done using arrow keys or buttons)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Test Focus on slides

## Note
To handle ordering some CSS had to be added, might impact other projects
