### PR TITLE
fix: a11y on pagination for alerts

### DIFF
--- a/libs/stack/stack-ui/src/components/Alerts/alerts.stories.mdx
+++ b/libs/stack/stack-ui/src/components/Alerts/alerts.stories.mdx
@@ -206,7 +206,6 @@ export const Template = (args) => (
       alerts: [
         {
           id: '1',
-          title: 'Alert 1 title',
           'aria-label': 'Alert 1 aria',
           icon: 'X',
           content: (

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import slugify from 'slugify'
 import { useSwiperSlide } from 'swiper/react'
 import useThemeContext from '../../../providers/Theme/hooks'
 import Box from '../../Box'
@@ -15,7 +16,7 @@ const AlertsItem = (props: TAlertsItemProps) => {
   if (!title && !button && !content && !icon) return null
 
   return (
-    <>
+    <Box as="div" {...{ id: slugify(`${id}-${title}`) }}>
       {icon && <Icon icon={icon} themeName={`${themeName}.icon`} tokens={tokens} />}
       {(title || button || content) && (
         <Box themeName={`${themeName}.container`}>
@@ -33,7 +34,7 @@ const AlertsItem = (props: TAlertsItemProps) => {
               : content)}
         </Box>
       )}
-    </>
+    </Box>
   )
 }
 

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -32,6 +32,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
     itemRoleDescriptionMessage = 'slide',
     slideRole = 'group',
     containerRoleDescriptionMessage = 'carousel',
+    paginationGroupLabel = 'pagination',
   } = a11y ?? {}
 
   const itemWrapperTheme = useThemeContext(`${themeName}.item.wrapper`, tokens, customTheme)
@@ -75,6 +76,7 @@ const AlertsSwiper = (props: TAlertsProps) => {
           activeIndex={activeIndex}
           alerts={alerts}
           controller={controller}
+          paginationGroupLabel={paginationGroupLabel}
         />
       )}
       <Swiper

--- a/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/AlertsSwiper.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import * as swiperModules from 'swiper/modules'
+import type { SwiperClass } from 'swiper/react'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import useThemeContext from '../../../providers/Theme/hooks'
 import type { TAlertsComponentProps, TAlertsProps } from '../interface'
@@ -7,6 +8,7 @@ import AlertsItem from './AlertsItem'
 import 'swiper/css'
 import 'swiper/css/pagination'
 import { AlertsNextNavigationButton, AlertsPrevNavigationButton } from './AlertsNavigationButton'
+import AlertsPagination from './pagination/AlertsPagination'
 
 const AlertsSwiper = (props: TAlertsProps) => {
   const {
@@ -35,15 +37,18 @@ const AlertsSwiper = (props: TAlertsProps) => {
   const itemWrapperTheme = useThemeContext(`${themeName}.item.wrapper`, tokens, customTheme)
   const swiperTheme = useThemeContext(`${themeName}.swiper.swiper`, tokens, customTheme)
   const swiperWrapperTheme = useThemeContext(`${themeName}.swiper.wrapper`, tokens, customTheme)
-  const paginationWrapperTheme = useThemeContext(`${themeName}.pagination.wrapper`, tokens)
-  const paginationBulletTheme = useThemeContext(`${themeName}.pagination.bullet`, tokens) ?? 'swiper-pagination-bullet'
-  const paginationActiveBulletTheme = useThemeContext(`${themeName}.pagination.activeBullet`, tokens)
 
   const defaultModules: TAlertsComponentProps['modules'] = ['Keyboard', 'A11y']
 
-  const importedModules = [...(modules ?? []), ...defaultModules].map((module) => swiperModules[module])
+  const importedModules = [...(modules?.filter((module) => module !== 'Pagination') ?? []), ...defaultModules].map(
+    (module) => swiperModules[module],
+  )
 
   const hasNavigation = modules?.includes('Navigation')
+  const hasPagination = modules?.includes('Pagination')
+
+  const [controller, setController] = useState<SwiperClass>()
+  const [activeIndex, setActiveIndex] = useState<number>(0)
 
   return (
     <>
@@ -63,16 +68,24 @@ const AlertsSwiper = (props: TAlertsProps) => {
           aria-label={a11y?.nextSlideMessage}
         />
       )}
+      {hasPagination && (
+        <AlertsPagination
+          themeName={`${themeName}.pagination`}
+          tokens={tokens}
+          activeIndex={activeIndex}
+          alerts={alerts}
+          controller={controller}
+        />
+      )}
       <Swiper
         tabIndex={0}
         {...rest}
-        navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
-        pagination={{
-          bulletClass: paginationBulletTheme,
-          clickableClass: paginationWrapperTheme,
-          bulletActiveClass: paginationActiveBulletTheme,
-          clickable: true,
+        onSwiper={(c) => {
+          setController(c)
+          setActiveIndex(c.activeIndex)
         }}
+        onSlideChange={(c) => setActiveIndex(c.activeIndex)}
+        navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
         role="group"
         aria-roledescription={containerRoleDescriptionMessage ?? undefined}
         slidesPerView={slidesPerView}

--- a/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPagination.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPagination.tsx
@@ -1,0 +1,33 @@
+import useThemeContext from 'libs/stack/stack-ui/src/providers/Theme/hooks'
+import type { TAlertsPaginationProps } from '../../interface'
+
+const AlertsPagination = (props: TAlertsPaginationProps) => {
+  const { themeName, tokens, controller, alerts, activeIndex } = props
+  const paginationWrapperTheme = useThemeContext(`${themeName}.wrapper`, tokens)
+  const paginationBulletTheme = useThemeContext(`${themeName}.bullet`, tokens)
+  const paginationActiveBulletTheme = useThemeContext(`${themeName}.activeBullet`, tokens)
+
+  return (
+    <div className={paginationWrapperTheme} role="group">
+      {alerts.map((_, index) => (
+        <span
+          tabIndex={0}
+          role="button"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              controller?.slideTo(index)
+            }
+          }}
+          onClick={() => controller?.slideTo(index)}
+          key={JSON.stringify(_)}
+          className={`${paginationBulletTheme} ${activeIndex === index ? paginationActiveBulletTheme : ''}`}
+          aria-current={index === activeIndex ? 'true' : 'false'}
+          aria-label={`${index + 1} of ${alerts.length}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default AlertsPagination

--- a/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPagination.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPagination.tsx
@@ -1,29 +1,22 @@
 import useThemeContext from 'libs/stack/stack-ui/src/providers/Theme/hooks'
 import type { TAlertsPaginationProps } from '../../interface'
+import AlertsPaginationBullet from './AlertsPaginationBullet'
 
 const AlertsPagination = (props: TAlertsPaginationProps) => {
-  const { themeName, tokens, controller, alerts, activeIndex } = props
+  const { themeName, tokens, controller, alerts, activeIndex, paginationGroupLabel } = props
   const paginationWrapperTheme = useThemeContext(`${themeName}.wrapper`, tokens)
-  const paginationBulletTheme = useThemeContext(`${themeName}.bullet`, tokens)
-  const paginationActiveBulletTheme = useThemeContext(`${themeName}.activeBullet`, tokens)
 
   return (
-    <div className={paginationWrapperTheme} role="group">
+    <div className={paginationWrapperTheme} role="group" aria-label={paginationGroupLabel}>
       {alerts.map((_, index) => (
-        <span
-          tabIndex={0}
-          role="button"
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-              event.preventDefault()
-              controller?.slideTo(index)
-            }
-          }}
-          onClick={() => controller?.slideTo(index)}
+        <AlertsPaginationBullet
           key={JSON.stringify(_)}
-          className={`${paginationBulletTheme} ${activeIndex === index ? paginationActiveBulletTheme : ''}`}
-          aria-current={index === activeIndex ? 'true' : 'false'}
-          aria-label={`${index + 1} of ${alerts.length}`}
+          index={index}
+          activeIndex={activeIndex}
+          alerts={alerts}
+          controller={controller}
+          themeName={themeName}
+          tokens={tokens}
         />
       ))}
     </div>

--- a/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPaginationBullet.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPaginationBullet.tsx
@@ -1,0 +1,33 @@
+import useThemeContext from 'libs/stack/stack-ui/src/providers/Theme/hooks'
+import type { TAlertsPaginationBulletProps } from '../../interface'
+
+const AlertsPaginationBullet = (props: TAlertsPaginationBulletProps) => {
+  const { themeName, tokens, controller, alerts, activeIndex, index } = props
+
+  const paginationBulletTheme = useThemeContext(`${themeName}.bullet`, tokens)
+  const paginationActiveBulletTheme = useThemeContext(`${themeName}.activeBullet`, tokens)
+  const alert = alerts[index]
+  const isActive = index === activeIndex
+
+  return (
+    <span
+      tabIndex={0}
+      role="button"
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          controller?.slideTo(index)
+        }
+      }}
+      onClick={() => controller?.slideTo(index)}
+      key={JSON.stringify(alert)}
+      className={`${paginationBulletTheme} ${isActive ? paginationActiveBulletTheme : ''}`}
+      aria-current={isActive ? 'true' : 'false'}
+      aria-label={`${index + 1} of ${alerts.length}`}
+      aria-disabled={isActive}
+      aria-labelledby={alert.title}
+    />
+  )
+}
+
+export default AlertsPaginationBullet

--- a/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPaginationBullet.tsx
+++ b/libs/stack/stack-ui/src/components/Alerts/components/pagination/AlertsPaginationBullet.tsx
@@ -1,4 +1,5 @@
 import useThemeContext from 'libs/stack/stack-ui/src/providers/Theme/hooks'
+import slugify from 'slugify'
 import type { TAlertsPaginationBulletProps } from '../../interface'
 
 const AlertsPaginationBullet = (props: TAlertsPaginationBulletProps) => {
@@ -8,6 +9,9 @@ const AlertsPaginationBullet = (props: TAlertsPaginationBulletProps) => {
   const paginationActiveBulletTheme = useThemeContext(`${themeName}.activeBullet`, tokens)
   const alert = alerts[index]
   const isActive = index === activeIndex
+  const { title, id } = alert
+
+  const hasTitle = title && title.length > 0
 
   return (
     <span
@@ -23,9 +27,9 @@ const AlertsPaginationBullet = (props: TAlertsPaginationBulletProps) => {
       key={JSON.stringify(alert)}
       className={`${paginationBulletTheme} ${isActive ? paginationActiveBulletTheme : ''}`}
       aria-current={isActive ? 'true' : 'false'}
-      aria-label={`${index + 1} of ${alerts.length}`}
+      aria-label={!hasTitle ? `${index + 1} / ${alerts.length}` : undefined}
       aria-disabled={isActive}
-      aria-labelledby={alert.title}
+      aria-labelledby={hasTitle ? slugify(`${id}-${title}`) : undefined}
     />
   )
 }

--- a/libs/stack/stack-ui/src/components/Alerts/interface.ts
+++ b/libs/stack/stack-ui/src/components/Alerts/interface.ts
@@ -1,6 +1,6 @@
 import type React from 'react'
 import type * as SwiperModules from 'swiper/modules'
-import type { SwiperProps } from 'swiper/react'
+import type { SwiperClass, SwiperProps } from 'swiper/react'
 import type { TDefaultComponent } from '../../types/components'
 import type { TButtonProps } from '../Button/interface'
 import type { LightboxProps } from '../Lightbox/interface'
@@ -16,6 +16,12 @@ export interface TAlertsItem {
   ariaLabel?: string
   content?: React.ReactNode
   button?: TButtonProps
+}
+
+export interface TAlertsPaginationProps extends TDefaultComponent {
+  activeIndex: number
+  alerts: TAlertsItem[]
+  controller?: SwiperClass
 }
 
 export interface TAlertsComponentProps

--- a/libs/stack/stack-ui/src/components/Alerts/interface.ts
+++ b/libs/stack/stack-ui/src/components/Alerts/interface.ts
@@ -1,6 +1,7 @@
 import type React from 'react'
 import type * as SwiperModules from 'swiper/modules'
 import type { SwiperClass, SwiperProps } from 'swiper/react'
+import type { A11yOptions } from 'swiper/types'
 import type { TDefaultComponent } from '../../types/components'
 import type { TButtonProps } from '../Button/interface'
 import type { LightboxProps } from '../Lightbox/interface'
@@ -22,11 +23,23 @@ export interface TAlertsPaginationProps extends TDefaultComponent {
   activeIndex: number
   alerts: TAlertsItem[]
   controller?: SwiperClass
+  paginationGroupLabel?: string
+}
+
+export interface TAlertsPaginationBulletProps extends TDefaultComponent {
+  activeIndex: number
+  alerts: TAlertsItem[]
+  controller?: SwiperClass
+  index: number
+}
+interface TCustomA11yOptions extends A11yOptions {
+  paginationGroupLabel?: string
 }
 
 export interface TAlertsComponentProps
   extends Omit<TDefaultComponent, 'children'>,
-    Omit<SwiperProps, 'children' | 'modules'> {
+    Omit<SwiperProps, 'children' | 'modules' | 'a11y'> {
+  a11y?: TCustomA11yOptions
   alerts: TAlertsItem[]
   children?: (props: TAlertsItemProps) => React.ReactNode
   modules?: (keyof typeof SwiperModules)[]

--- a/libs/stack/stack-ui/src/theme/Alerts/index.ts
+++ b/libs/stack/stack-ui/src/theme/Alerts/index.ts
@@ -7,7 +7,7 @@ const alertsWrapper = tv({
 })
 
 const alertsContainer = tv({
-  base: 'flex justify-between items-center gap-4',
+  base: 'flex justify-between items-center gap-4 relative',
 })
 
 const alertsCloseBtn = tv({
@@ -57,7 +57,7 @@ const alertsNavigationButton = tv({
 })
 
 const alertsPaginationWrapper = tv({
-  base: 'flex gap-4 justify-center',
+  base: 'flex gap-4 justify-center absolute z-10 bottom-4 left-0 right-0',
 })
 
 const alertsPaginationBullet = tv({

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "nx-cloud": "16.5.2",
     "postcss": "8.4.32",
     "prettier": "^3.1.1",
+    "slugify": "1.6.6",
     "swc-loader": "0.2.3",
     "tailwindcss": "3.4.0",
     "tailwindcss-logical": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19030,6 +19030,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.6.tgz#2d4ac0eacb47add6af9e04d3be79319cbcc7924b"
+  integrity sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==
+
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-160

## Implementation details
- [x] Pagination should be accessed using tabs before the selected slide item

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Check if all a11y features are present for pagination since I needed to remake this feature from scratch
