### PR TITLE
docs: clearer blocks dispatcher doc, include blocks prop

### DIFF
--- a/libs/directus/directus-block/README.md
+++ b/libs/directus/directus-block/README.md
@@ -10,10 +10,15 @@ Run `nx build directus-block` to build the library.
 
 ### Dispatcher
 
-This component will loop over every block it is sent and call the Serializer. It is possible to wrap children in any component by passing a function to children, just like so:
+#### Props
+
+- config: Configuration the block dispatcher will use. This configuration will get merged with the base config of directus-block. In case of overrides, the passed configuration will always win over the directus-block configuration.
+- blocks: Array of `TBlockSerializerProps` containing the actual blocks data. This is the prop that will be used by the block dispatcher to iterate through its children.
+- block: In case you want to pass a single block
+- children: Function receiving the current block `TBlockSerializerProps` as props. Will use BlockSerializer alone by default. This is useful in scenarios where you want every block to be wrapped in other components:
 
 ```tsx
-  <BlockDispatcher config={baseBlockDispatcherConfig}>
+  <BlockDispatcher config={baseBlockDispatcherConfig} blocks={blocks}>
     {(block) => (
       <Container tokens={{ isLowestContainerLevel: true }}>
         <ErrorBoundary fallback={<ErrorFallback />}>
@@ -26,13 +31,11 @@ This component will loop over every block it is sent and call the Serializer. It
 
 This would allow to remove a lot of repetitive code accross blocks definitions, for example as they all need to be wrapped in a `Container` and an `ErrorBoundary`
 
-If no children are passed, the Dispatcher will map every block using only the Serializer component.
-
 ### Serializer
 
 This component calls the good component in the configuration from the `collection` prop
 
-### Configuration
+## Configuration
 
 A configuration uses the `components` prop to map a key value, like so:
 
@@ -56,7 +59,7 @@ const config = {
 }
 ```
 
-#### Props
+### Props
 
 - default: The default component if no variants/invalid variants are used
 - defaultVariant: Overrides the default use of the `default` prop, instead mapping the default component on a specific variant
@@ -82,7 +85,7 @@ const brandConfig = {
 <BlockDispatcher config={brandConfig} />
 ```
 
-#### Overriding the configuration with brand blocks
+### Overriding the configuration with brand blocks
 
 To override the base block dispatcher configuration, you name a block component configuration with the same key as the ones in the configuration.
 
@@ -140,7 +143,7 @@ const brandConfig = {
 <BlockDispatcher config={brandConfig} />
 ```
 
-#### Extending the configuration with stack blocks
+### Extending the configuration with stack blocks
 
 Some blocks may be in the Stack without being in the base configuration. To use them, simply import their own configuration from the stack and spread them in yours
 


### PR DESCRIPTION
## Issue Link
https://github.com/OKAMca/cepsum-mono/blob/CEP-156-Brand-ui-Alerts/libs/ui/src/components/Alerts/components/AlertsNextButton.tsx

## Implementation details
- [x] Update blocks dispatcher block to describe the use of blocks prop

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Explanation of how to test this PR with a link when applicable.
