### PR TITLE
Stack 180 directus image add an option for passing the image domain

### DIFF
--- a/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
+++ b/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
@@ -2,12 +2,28 @@ import { createPngDataUri } from 'unlazy/thumbhash'
 import Img from '../Img'
 import type TDirectusImageProps from './interface'
 
-const imgDomain = process.env.NEXT_PUBLIC_IMG_DOMAIN ?? ''
+const envImgDomain = process.env.NEXT_PUBLIC_IMG_DOMAIN
 
 const DirectusImg = (props: TDirectusImageProps) => {
-  const { fit, customTheme, thumbhash, description, width, height, id, filenameDownload, ...rest } = props
+  const {
+    fit,
+    customTheme,
+    thumbhash,
+    description,
+    width,
+    height,
+    id,
+    filenameDownload,
+    imgDomain = envImgDomain,
+    ...rest
+  } = props
 
   if (!id || !filenameDownload) return null
+
+  if (!imgDomain) {
+    console.warn('No image domain was provided')
+    return null
+  }
 
   const getDirectusImage = () => {
     try {

--- a/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
+++ b/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
@@ -21,6 +21,7 @@ const DirectusImg = (props: TDirectusImageProps) => {
   if (!id || !filenameDownload) return null
 
   if (!imgDomain) {
+    // eslint-disable-next-line no-console
     console.warn('No image domain was provided')
     return null
   }

--- a/libs/stack/stack-ui/src/components/DirectusImg/interface.ts
+++ b/libs/stack/stack-ui/src/components/DirectusImg/interface.ts
@@ -10,6 +10,10 @@ type TDirectusImageProps = Omit<TImgProps, 'src' | 'id' | 'width' | 'height' | '
   height: Nullable<number>
   id: Nullable<string>
   filenameDownload: Nullable<string>
+  /**
+   * @default NEXT_PUBLIC_IMG_DOMAIN
+   */
+  imgDomain?: string
 }
 
 export default TDirectusImageProps


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-180

## Implementation details
- [x] Add a way to pass the image domain the Directus image component
- [x] Passed image domain should fall back to environment variable image domain

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)
