### PR TITLE
chore(release): flexible content access to public

### DIFF
--- a/libs/directus/directus-flexible-content/package.json
+++ b/libs/directus/directus-flexible-content/package.json
@@ -8,5 +8,8 @@
       "import": "./index.mjs",
       "require": "./index.js"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Issue Link

## Implementation details
- [x] directus-flexible-content NPM package access should be public

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)
