### PR TITLE
fix(directus-block): export server components

### DIFF
--- a/libs/directus/directus-block/package.json
+++ b/libs/directus/directus-block/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@okam/directus-block",
-  "main": "./index.js",
   "version": "1.2.2",
+  "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": "./index.mjs",
       "require": "./index.js"
+    },
+    "./server": {
+      "import": "./server.mjs",
+      "require": "./server.js"
     }
   },
   "publishConfig": {

--- a/libs/directus/directus-block/vite.config.ts
+++ b/libs/directus/directus-block/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   build: {
     lib: {
       // Could also be a dictionary or array of multiple entry points.
-      entry: 'src/index.ts',
+      entry: ['src/index.ts', 'src/server.ts'],
       name: 'directus-block',
       fileName: 'index',
       // Change this to the formats you want to support.
@@ -47,5 +47,6 @@ export default defineConfig({
       // External packages that should not be bundled into your library.
       external: externalDeps,
     },
+    ssr: true,
   },
 })

--- a/libs/directus/directus-block/vite.config.ts
+++ b/libs/directus/directus-block/vite.config.ts
@@ -39,13 +39,14 @@ export default defineConfig({
       entry: ['src/index.ts', 'src/server.ts'],
       name: 'directus-block',
       fileName: 'index',
+
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.
-      external: externalDeps,
+      external: [...externalDeps, '@okam/stack-ui'],
     },
     ssr: true,
   },


### PR DESCRIPTION
## Issue Link

## Implementation details
- [x] directus-block should export server components

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)
