### PR TITLE
fix: allow changing directus img protocol

### DIFF
--- a/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
+++ b/libs/stack/stack-ui/src/components/DirectusImg/index.tsx
@@ -15,6 +15,7 @@ const DirectusImg = (props: TDirectusImageProps) => {
     id,
     filenameDownload,
     imgDomain = envImgDomain,
+    protocol = 'https',
     ...rest
   } = props
 
@@ -28,7 +29,7 @@ const DirectusImg = (props: TDirectusImageProps) => {
 
   const getDirectusImage = () => {
     try {
-      const img = new URL(`/assets/${id}/${filenameDownload}`, `https://${imgDomain}`)
+      const img = new URL(`/assets/${id}/${filenameDownload}`, `${protocol}://${imgDomain}`)
       img.searchParams.set('fit', fit ?? 'contain')
       return img
     } catch (error) {

--- a/libs/stack/stack-ui/src/components/DirectusImg/interface.ts
+++ b/libs/stack/stack-ui/src/components/DirectusImg/interface.ts
@@ -14,6 +14,7 @@ type TDirectusImageProps = Omit<TImgProps, 'src' | 'id' | 'width' | 'height' | '
    * @default NEXT_PUBLIC_IMG_DOMAIN
    */
   imgDomain?: string
+  protocol?: 'http' | 'https'
 }
 
 export default TDirectusImageProps


### PR DESCRIPTION
## Issue Link

Sometimes we need images pointing to http, not https. This allows to change the protocol to http

## Implementation details
- [x] Add a prop for changing Directus img protocol

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Explanation of how to test this PR with a link when applicable.
