### PR TITLE
fix(directus-node): fix package.json with published structured reference

### DIFF
--- a/libs/directus/directus-node/package.json
+++ b/libs/directus/directus-node/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@okam/directus-node",
-  "main": "./index.js",
+  "main": "./src/index.js",
   "version": "0.1.1",
-  "types": "./index.d.ts",
+  "types": "./src/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/CEP-217

## Implementation details
- [ ] package.json main and types properties should provide the same path that published files: https://www.npmjs.com/package/@okam/directus-node?activeTab=code

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- after publishing, require of @okam/directus-node should work
