### PR TITLE
fix(directus-flexible-content): add stack-ui and directus block to external deps

### DIFF
--- a/libs/directus/directus-flexible-content/src/index.ts
+++ b/libs/directus/directus-flexible-content/src/index.ts
@@ -1,2 +1,4 @@
-export * from './lib/components'
-export * from './lib/functions'
+export { FlexibleEditorContent } from './lib/components'
+export { RenderNodes } from './lib/components'
+export type { TRenderingNodes } from './lib/components/nodes/types'
+export type { JSONContent } from './lib/functions/types'

--- a/libs/directus/directus-flexible-content/src/lib/components/nodes/types.ts
+++ b/libs/directus/directus-flexible-content/src/lib/components/nodes/types.ts
@@ -2,7 +2,7 @@ import type { TDefaultComponent } from '@okam/stack-ui'
 
 export interface TBaseRenderingNode extends TDefaultComponent {
   children: React.ReactNode
-  attrs?: Record<string, number | string | undefined>
+  attrs?: Record<string, number | string | boolean | undefined>
 }
 
 export type TRenderingNodes = { [key in keyof JSX.IntrinsicElements]?: (props: TBaseRenderingNode) => JSX.Element }

--- a/libs/directus/directus-flexible-content/vite.config.ts
+++ b/libs/directus/directus-flexible-content/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.
-      external: externalDeps,
+      external: [...externalDeps, '@okam/stack-ui', '@okam/directus-block'],
     },
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -40570,7 +40570,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "8.0.3",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -41068,7 +41068,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "5.1.0",
+      "version": "5.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",


### PR DESCRIPTION
add stack-ui and directus block to external deps

## Implementation details
- [x] Build should include stack-ui and directus-block in external deps
- [x] Add boolean option to TBaseRenderingNode type

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)
