### PR TITLE
fix(directus-flexible-editor): fixed content injection and prop name

### DIFF
--- a/apps/demo/app/flexible-editor/page.tsx
+++ b/apps/demo/app/flexible-editor/page.tsx
@@ -23,7 +23,7 @@ export default async function Index() {
 
   return (
     <FlexibleEditorContent
-      flexibleEditor={content}
+      jsonContent={content}
       editorNodes={editorNodes}
       config={relationBlocks}
       nodes={{

--- a/libs/directus/directus-flexible-content/src/lib/components/FlexibleEditorContent/index.tsx
+++ b/libs/directus/directus-flexible-content/src/lib/components/FlexibleEditorContent/index.tsx
@@ -10,7 +10,7 @@ import RenderNodes from '../RenderNodes'
 import extensions from './extensions'
 
 interface FlexibleEditorContentProps extends TDefaultComponent {
-  flexibleEditor: JSONContent
+  jsonContent: JSONContent
   editorNodes?: EditorNodes[] | undefined | null
   serializers?: Extensions
   config?: TBlockSerializerConfig
@@ -19,19 +19,10 @@ interface FlexibleEditorContentProps extends TDefaultComponent {
 }
 
 const FlexibleEditorContent = (props: FlexibleEditorContentProps) => {
-  const {
-    flexibleEditor,
-    editorNodes,
-    serializers,
-    nodes,
-    config,
-    themeName,
-    tokens,
-    customTheme,
-    remappedAttributes,
-  } = props
+  const { jsonContent, editorNodes, serializers, nodes, config, themeName, tokens, customTheme, remappedAttributes } =
+    props
 
-  const content = injectDataIntoContent(editorNodes, flexibleEditor)
+  const content = injectDataIntoContent(editorNodes, jsonContent)
 
   // `.slice(0)` to clone the extensions array
   const effectiveSerializers = serializers ?? [...extensions] ?? []

--- a/libs/directus/directus-flexible-content/src/lib/functions/injectDataIntoContent.ts
+++ b/libs/directus/directus-flexible-content/src/lib/functions/injectDataIntoContent.ts
@@ -8,6 +8,7 @@ const injectDataIntoContent = (
   itemField = 'item',
 ) => {
   const toContentWithInjectedData = (jsonContent: JSONContent) => {
+    if (!data && jsonContent) return jsonContent
     if (!jsonContent || !data) return null
 
     if (jsonContent.type === 'relation-block' && jsonContent.attrs?.id) {


### PR DESCRIPTION
## Implementation details
- [x] Changed prop name `flexibleEditor` to `jsonContent` (better name)
- [x] Added default return if no editorNodes are passed but jsonContent is still present

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Explanation of how to test this PR with a link when applicable.
