### PR TITLE
STACK-189-DirectusLink-Accessibility-props-other-fixes

### DIFF
--- a/apps/demo/app/directus-next-component/directus-link/page.tsx
+++ b/apps/demo/app/directus-next-component/directus-link/page.tsx
@@ -152,7 +152,7 @@ function renderTree(tree: Nullable<TNavigationItemsTree>): React.ReactNode {
   if (!link || !linkProps) return null
   if (!children) {
     return (
-      <li style={style}>
+      <li style={style} key={linkProps?.id}>
         {/* You can render your own component with linkProps */}
         <BrandDirectusLink {...linkProps} />
         {/* Or use the pre-rendered version */}
@@ -168,7 +168,7 @@ function renderTree(tree: Nullable<TNavigationItemsTree>): React.ReactNode {
   }
   return (
     <ul>
-      <li style={style}>
+      <li style={style} key={linkProps?.id}>
         <div>
           <BrandDirectusLink {...linkProps} />
         </div>

--- a/libs/directus/directus-next-component/README.md
+++ b/libs/directus/directus-next-component/README.md
@@ -40,16 +40,16 @@ The directus link component uses the directus link hook, which means it can be p
 
 By default, the following are included:
 
-- Collection: Render a link using a `page_settings` relation
-- Anchor: Render a link pointing to an element's id on the page (always starts with `#`)
-- ExternalLink: Render a link with an external URL (e.g.: https://google.com)
-- File: Render a link for a downloadable file
+- `collection`: Render a link using a `page_settings` relation
+- `anchor`: Render a link pointing to an element's id on the page (always starts with `#`)
+- `external-link`: Render a link with an external URL (e.g.: https://google.com)
+- `file`: Render a link for a downloadable file
 
 The mentionned configuration can be overwritten by passing a `componentsConfig` prop to the directus link component
 
 ```jsx
 const overrideConfig = {
-  ExternalLink: (props) => <CustomExternalLinkComponent {...props} />
+  'external-link': (props) => <CustomExternalLinkComponent {...props} />
 }
 
 const BrandLink = (props) => {
@@ -62,6 +62,10 @@ const BrandLink = (props) => {
 The `useNavigationItems` hook allows to build recursively a navigation structure using the `DirectusLink` component. 
 
 ### Props
+
+
+
+### Returned props of each parsed navigation item in the tree
 
 - `link`: A rendered react node of the `DirectusLink` component
 - `linkProps`: The props that were passed to the link
@@ -82,10 +86,6 @@ const depthMap: Record<number, object> = {
 // Loop recursively through navigation items and assign style based on depth
 function renderTree(tree: Nullable<TNavigationItemsTree>): React.ReactNode {
   if (!tree) return null
-  /*
-   * Here, `link` represents a rendered version of `DirectusLink` for quick use
-   * Use `linkProps` for custom rendering needs
-   */
   const { children, link, linkProps, depth } = tree
   const style = depthMap[depth]
 
@@ -93,6 +93,12 @@ function renderTree(tree: Nullable<TNavigationItemsTree>): React.ReactNode {
   if (!children) {
     return (
       <li style={style} key={link.id}>
+        {
+          /*
+           * Here, `link` represents a rendered version of `DirectusLink` for quick use
+           * Use `linkProps` for custom rendering needs
+           */
+        }
         {link}
       </li>
     )

--- a/libs/directus/directus-next-component/src/components/DirectusLink/index.tsx
+++ b/libs/directus/directus-next-component/src/components/DirectusLink/index.tsx
@@ -1,5 +1,4 @@
 import { Anchor } from '@okam/stack-ui'
-import Link from 'next/link'
 import useDirectusLink from '../../hooks/directus-link'
 import type { TDirectusLinkProps } from './interface'
 
@@ -12,7 +11,7 @@ const DirectusLink = (props: TDirectusLinkProps) => {
 
   const LinkComponent = componentsConfig?.[type]
 
-  if (!LinkComponent) return <Anchor as={Link} {...linkProps} />
+  if (!LinkComponent) return <Anchor {...linkProps} />
   return <LinkComponent {...props} />
 }
 

--- a/libs/directus/directus-next-component/src/components/DirectusLink/index.tsx
+++ b/libs/directus/directus-next-component/src/components/DirectusLink/index.tsx
@@ -7,12 +7,15 @@ const DirectusLink = (props: TDirectusLinkProps) => {
 
   const linkProps = useDirectusLink(props)
 
-  if (!type || !linkProps.href) return null
+  if (!type) return null
 
   const LinkComponent = componentsConfig?.[type]
 
-  if (!LinkComponent) return <Anchor {...linkProps} />
-  return <LinkComponent {...props} />
+  if (LinkComponent) return <LinkComponent {...props} />
+
+  if (!linkProps.href) return null
+
+  return <Anchor {...linkProps} />
 }
 
 export default DirectusLink

--- a/libs/directus/directus-next-component/src/components/DirectusLink/interface.ts
+++ b/libs/directus/directus-next-component/src/components/DirectusLink/interface.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { TDefaultComponent, TAnchorProps } from '@okam/stack-ui'
-import type { ComponentType } from 'react'
+import type { AriaAttributes, ComponentType } from 'react'
 import type { TLinks } from '../../types/links'
 
-export interface TDirectusLinkProps extends Omit<TDefaultComponent, 'children'>, Omit<Partial<TLinks>, 'tokens'> {
+export interface TDirectusLinkProps
+  extends Omit<TDefaultComponent, 'children'>,
+    Omit<Partial<TLinks>, 'tokens'>,
+    AriaAttributes {
   componentsConfig?: TDirectusLinkComponentsConfig
   propsConfig?: TDirectusLinkPropsConfig
 }

--- a/libs/directus/directus-next-component/src/components/DirectusLink/interface.ts
+++ b/libs/directus/directus-next-component/src/components/DirectusLink/interface.ts
@@ -1,13 +1,13 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { TDefaultComponent, TAnchorProps } from '@okam/stack-ui'
 import type { AriaAttributes, ComponentType } from 'react'
 import type { TLinks } from '../../types/links'
 
-export interface TDirectusLinkProps
-  extends Omit<TDefaultComponent, 'children'>,
-    Omit<Partial<TLinks>, 'tokens'>,
-    AriaAttributes {
+export type TDirectusLink = Omit<TDefaultComponent, 'children'> & Omit<Partial<TLinks>, 'tokens'> & AriaAttributes
+
+export interface TUseDirectusLink extends TDirectusLink {
+  propsConfig?: TDirectusLinkPropsConfig
+}
+export interface TDirectusLinkProps extends TDirectusLink {
   componentsConfig?: TDirectusLinkComponentsConfig
   propsConfig?: TDirectusLinkPropsConfig
 }
@@ -16,5 +16,5 @@ export type TDirectusLinkComponentsConfig = Record<string, ComponentType<TDirect
 
 export type TDirectusLinkPropsConfig<ReturnProps extends TAnchorProps = TAnchorProps> = Record<
   string,
-  (props: TDirectusLinkProps) => ReturnProps
+  (props: TUseDirectusLink) => ReturnProps
 >

--- a/libs/directus/directus-next-component/src/hooks/directus-link.ts
+++ b/libs/directus/directus-next-component/src/hooks/directus-link.ts
@@ -60,6 +60,13 @@ export default function useDirectusLink(props: TUseDirectusLink): TAnchorProps {
     customTheme,
     propsConfig,
     as = Link,
+    target,
+    anchor,
+    collection,
+    external_link: externalLink,
+    file,
+    id,
+    ...rest
   } = props
 
   if (!type) return {}
@@ -68,15 +75,16 @@ export default function useDirectusLink(props: TUseDirectusLink): TAnchorProps {
 
   const linkProps = finalConfig[type]?.(props) ?? {}
 
-  const { href, ...rest } = linkProps
+  const { href, ...restOfLinkProps } = linkProps
 
   if (!href) return {}
 
   return {
+    ...rest,
     as,
-    themeName,
+    ...(themeName ? { themeName } : {}),
+    ...(customTheme ? { customTheme } : {}),
     tokens: { ...tokens, ...(variant ? { type: variant } : {}) },
-    customTheme,
     nextLinkProps: {
       href,
       prefetch: prefetch ?? undefined,
@@ -85,6 +93,6 @@ export default function useDirectusLink(props: TUseDirectusLink): TAnchorProps {
     },
     href,
     children: label,
-    ...rest,
+    ...restOfLinkProps,
   }
 }

--- a/libs/directus/directus-next-component/src/hooks/directus-link.ts
+++ b/libs/directus/directus-next-component/src/hooks/directus-link.ts
@@ -1,4 +1,5 @@
 import type { TAnchorProps } from '@okam/stack-ui'
+import Link from 'next/link'
 import type { TDirectusLinkProps, TDirectusLinkPropsConfig } from '../components/DirectusLink/interface'
 import useDirectusFile from './directus-file'
 
@@ -26,7 +27,19 @@ const defaultPropsConfig: TDirectusLinkPropsConfig = {
 }
 
 export default function useDirectusLink(props: TDirectusLinkProps): TAnchorProps {
-  const { type, label, prefetch, replace, scroll, variant, tokens, themeName, customTheme, propsConfig } = props
+  const {
+    type,
+    label,
+    prefetch,
+    replace,
+    scroll,
+    variant,
+    tokens,
+    themeName,
+    customTheme,
+    propsConfig,
+    as = Link,
+  } = props
 
   if (!type) return {}
 
@@ -37,6 +50,7 @@ export default function useDirectusLink(props: TDirectusLinkProps): TAnchorProps
   if (!href) return {}
 
   return {
+    as,
     themeName,
     tokens: { ...tokens, ...(variant ? { type: variant } : {}) },
     customTheme,

--- a/libs/directus/directus-next-component/src/hooks/directus-link.ts
+++ b/libs/directus/directus-next-component/src/hooks/directus-link.ts
@@ -45,7 +45,7 @@ export default function useDirectusLink(props: TDirectusLinkProps): TAnchorProps
 
   const finalConfig = { ...defaultPropsConfig, ...(propsConfig ?? {}) }
 
-  const { href, ...rest } = finalConfig[type](props)
+  const { href, ...rest } = finalConfig[type]?.(props) ?? {}
 
   if (!href) return {}
 

--- a/libs/directus/directus-next-component/src/hooks/navigation-items.tsx
+++ b/libs/directus/directus-next-component/src/hooks/navigation-items.tsx
@@ -61,6 +61,7 @@ function createChildrenTree<
 /**
  *
  * @param navigationItems A tree of navigation items, with parents and children
+ * @param onNavigationItem Called when a navigation item is about to be added to the tree
  * @returns A tree of navigation items with ready-to-use DirectusLink components
  */
 export default function useNavigationItems<

--- a/libs/directus/directus-next-component/src/index.ts
+++ b/libs/directus/directus-next-component/src/index.ts
@@ -9,4 +9,10 @@ export type { TFiles } from './types/files'
 export type { TPageSettings } from './types/page-settings'
 export type { TNavigationItems, TNavigationItemsTree } from './types/navigation-items'
 export type { TLinks } from './types/links'
-export type { TDirectusLinkProps } from './components/DirectusLink/interface'
+export type {
+  TDirectusLinkProps,
+  TUseDirectusLink,
+  TDirectusLink,
+  TDirectusLinkPropsConfig,
+  TDirectusLinkComponentsConfig,
+} from './components/DirectusLink/interface'


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-189

## Implementation details
- [x] Using useDirectusLink should not create a "passed `scroll` attribute as boolean instead of string" error
- [x] Should be able to pass aria attributes to directus link (even when creating a list of `TDirectusLinkProps` for mapping to components)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- /directus-next-component/directus-link
