### PR TITLE
STACK-200-Get-block-props-should-still-make-its-query-if-block-settings-are-defined

### DIFF
--- a/libs/directus/directus-block/src/utils/get-block-props.ts
+++ b/libs/directus/directus-block/src/utils/get-block-props.ts
@@ -19,8 +19,13 @@ function isVariables<BlockVariables extends Variables>(
   return !!maybeVariables
 }
 
-function isOnlyIdInItem(item: TCommonBlockFragment): item is TBlockVariables {
-  return !isEmpty(item) && Object.keys(item).length === 1 && Object.keys(item)[0] === 'id' && !!item.id
+/**
+ * Checks wether or not the item `getBlockProps` receives is valid, or if `getBlockProps` needs to query the item
+ * Since `id` and `settings` are the minimum props of a block, they don't count in the actual item's data
+ */
+function isItemEmpty(item: TCommonBlockFragment): item is TBlockVariables {
+  const { id, settings, ...restOfItem } = item ?? {}
+  return isEmpty(restOfItem)
 }
 
 async function queryFromVariables<
@@ -54,7 +59,7 @@ export default async function getBlockProps<
 
   if (item) {
     // If the item actually contains the block's data, just return it
-    if (!isOnlyIdInItem(item)) {
+    if (!isItemEmpty(item)) {
       return item
     }
 


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-200

Since id and settings are mandatory block fields, we should still query the item even if a block has only id and settings. Any prop other than id and settings will make the item be considered valid, and get block props won't make a query

## Implementation details
- [ ] getBlockProps should not make a query if only id and settings are defined

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- NextJS demo
- /directus-block
- in get-block-props file, at line 65, insert `console.log(item)`
- Should see the "if only id and settings are defined in item, the block should make a query" item id
