### PR TITLE
fix(stack-ui): remove nextlink deps on MenuItems component

### DIFF
--- a/libs/stack/stack-ui/src/components/Menu/components/MenuItems.tsx
+++ b/libs/stack/stack-ui/src/components/Menu/components/MenuItems.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import NextLink from 'next/link'
 import React, { useCallback, useRef } from 'react'
 import { useMenu } from '../../../providers/Menu'
 import Box from '../../Box'
@@ -51,6 +50,7 @@ const LinkElement = (menuItem: TMenuItemProps) => {
     tokens,
     nextLinkProps,
     children,
+    as,
     childItems,
     ...rest
   } = menuItem
@@ -73,8 +73,8 @@ const LinkElement = (menuItem: TMenuItemProps) => {
       }}
       ref={ref}
       key={`link-${id}`}
-      as={NextLink}
       target={target ?? '_self'}
+      as={as}
     >
       {React.isValidElement(children) ? children : label}
     </Anchor>
@@ -82,13 +82,13 @@ const LinkElement = (menuItem: TMenuItemProps) => {
 }
 
 const MenuItems = (props: TMenuItemsProps) => {
-  const { menuItems, children, themeName = 'menuItem', tokens, customTheme } = props
+  const { menuItems, children, themeName = 'menuItem', tokens, customTheme, menuLinkComponent } = props
 
   return (
     <Box themeName={`${themeName}.wrapper`} tokens={tokens} customTheme={customTheme}>
       <Box themeName={`${themeName}.container`} tokens={tokens} customTheme={customTheme}>
         {menuItems?.map((menuItem) => {
-          const { id, path, label, ...rest } = menuItem ?? {}
+          const { id, path, label, as, ...rest } = menuItem ?? {}
 
           const menuItemTokens = { ...tokens, ...menuItem.tokens }
 
@@ -119,6 +119,7 @@ const MenuItems = (props: TMenuItemsProps) => {
                   themeName={`${themeName}.anchor`}
                   tokens={menuItemTokens}
                   customTheme={customTheme}
+                  as={as ?? menuLinkComponent}
                 />
               )}
             </Box>

--- a/libs/stack/stack-ui/src/components/Menu/interface.ts
+++ b/libs/stack/stack-ui/src/components/Menu/interface.ts
@@ -28,6 +28,8 @@ export interface IMenuItemProp {
   path?: string
   label?: string
   nextLinkProps?: LinkProps
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: React.ElementType<any>
   onClick?: () => void
 }
 
@@ -35,6 +37,8 @@ export type TMenuItemProps = IMenuItemProp & TDefaultComponent & PartialHtmlBase
 
 export interface TMenuItemsProps extends TDefaultComponent {
   menuItems?: TMenuItemProps[] | null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  menuLinkComponent?: React.ElementType<any>
   children?: React.ReactNode
 }
 

--- a/libs/stack/stack-ui/src/storybook/Menu/Menu.tsx
+++ b/libs/stack/stack-ui/src/storybook/Menu/Menu.tsx
@@ -111,7 +111,7 @@ export const MenuFactory = ({
       <>
         {openBtn}
         <MenuComponent id={id} TransitionAnimation={RenderWithSlide as (props: unknown) => JSX.Element}>
-          <MenuItems menuItems={menuItems} />
+          <MenuItems menuLinkComponent="a" menuItems={menuItems} />
         </MenuComponent>
       </>
     </MenuContextProvider>


### PR DESCRIPTION
## Issue Link

## Implementation details
- [ ] Remove nextlink deps from MenuItems
- [ ] Allows set up custom component for MenuItems link

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

