### PR TITLE
STACK-201-Stop-directus-block-from-building-within-itself

### DIFF
--- a/libs/directus/directus-block/src/server.ts
+++ b/libs/directus/directus-block/src/server.ts
@@ -3,4 +3,5 @@
 export { default as BlockDispatcher } from './components/BlockDispatcher'
 export { default as BlockSerializer } from './components/BlockSerializer'
 export { default as getBlockProps } from './utils/get-block-props'
+export { default as useBlock } from './hooks/useBlock'
 export { default as mergeConfigs } from './utils/merge-configs'

--- a/libs/directus/directus-block/vite.config.ts
+++ b/libs/directus/directus-block/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.
-      external: [...externalDeps, '@okam/stack-ui'],
+      external: [...externalDeps, '@okam/stack-ui', '@okam/directus-query'],
       plugins: [preserveDirectives()],
       output: {
         preserveModules: true,


### PR DESCRIPTION
## Issue Link

https://okamca.atlassian.net/browse/STACK-201

## Implementation details
- [x] directus-block should build correctly
- [x] useBlock should be exported from directus-block/sercer

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- build directus-block
