### PR TITLE
STACK-203-Directus-links-of-type-file-should-return-valid-href

### DIFF
--- a/libs/directus/directus-next-component/src/hooks/directus-link.ts
+++ b/libs/directus/directus-next-component/src/hooks/directus-link.ts
@@ -7,10 +7,10 @@ function useFile(props: TUseDirectusLink) {
   const { file } = props
 
   const { filename_download: filenameDownload } = file ?? {}
-  const href = useDirectusFile(file)
+  const { src } = useDirectusFile(file) ?? {}
 
   return {
-    href: href?.toString() ?? undefined,
+    href: src,
     download: filenameDownload ?? true,
   }
 }


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-203

## Implementation details
- [x] Directus links of type file should render correct href (not object object)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- /directus-next-component/directus-link
- All links should render correctly
