### PR TITLE
fix(directus-node): adding limit = 200 for graphql redirects queries

### DIFF
--- a/libs/directus/directus-node/README.md
+++ b/libs/directus/directus-node/README.md
@@ -22,6 +22,12 @@ Run `nx test directus-node` to execute the unit tests via [Jest](https://jestjs.
  */
 const { fetchRedirects, getDefaultConfig } = require('@okam/directus-node')
 
+// getDefaultConfig() will return an object with
+// graphqlEndpoint: use environment variable NEXT_PUBLIC_GRAPHQL_URL
+// graphqlApiKey: use environment variable NEXT_API_TOKEN_ADMIN
+// redirectsFilename
+// rewritesFilename
+// limit: 2000  (number of redirect or rewrite rules fetched by graphql)
 fetchRedirects(getDefaultConfig())
 ```
 

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -5,7 +5,11 @@ interface TFetchRedirectsConfig {
   graphqlApiKey: string
   redirectsFilename: string
   rewritesFilename: string
+  limit: number | undefined
 }
+
+export const redirectDefaultLimit = 2000
+
 /**
  * Get Fetch Redirects Configuration
  * @returns {object}
@@ -16,11 +20,12 @@ export function getDefaultConfig(): TFetchRedirectsConfig {
     graphqlApiKey: process.env['NEXT_API_TOKEN_ADMIN'] || '',
     redirectsFilename: './redirect/redirects.json',
     rewritesFilename: './redirect/rewrites.json',
+    limit: redirectDefaultLimit,
   }
 }
 
 export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boolean> {
-  const { graphqlEndpoint, graphqlApiKey, redirectsFilename, rewritesFilename } = config
+  const { graphqlEndpoint, graphqlApiKey, redirectsFilename, rewritesFilename, limit } = config
 
   if (!graphqlEndpoint || !graphqlApiKey) {
     throw new Error('Missing graphql configuration: NEXT_PUBLIC_GRAPHQL_URL or NEXT_API_TOKEN_ADMIN')
@@ -30,14 +35,14 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
     throw new Error('Missing filename')
   }
 
-  const query = `query fetchRedirects {
-  redirects(filter: {status:{_eq:"published"},isrewrite:{_eq:false}}, sort: "sort") {
+  const query = `query fetchRedirects($limit: Int = 2000) {
+  redirects(filter: {status:{_eq:"published"},isrewrite:{_eq:false}}, sort: "sort", limit: $limit) {
     source
     destination
     permanent
     locale
   }
-  rewrites: redirects(filter: {status:{_eq:"published"},isrewrite:{_eq:true}}, sort: "sort") {
+  rewrites: redirects(filter: {status:{_eq:"published"},isrewrite:{_eq:true}}, sort: "sort", limit: $limit) {
     source
     destination
     permanent
@@ -48,7 +53,9 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
   const graphqlBody = {
     query,
     // "operationName": "",
-    variables: {},
+    variables: {
+      limit: Number(limit) || redirectDefaultLimit,
+    },
   }
 
   try {


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/P125-958

## Implementation details
- [ ] Adding configuration for graphql limit
- [ ] Set limit to 2000 by default, 1000 rules get a warning in next.js

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Explanation of how to test this PR with a link when applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for the `directus-node` library, providing clearer guidance on configuration options.
	- Introduced a limit feature for fetching redirects, allowing users to specify the maximum number of redirects retrieved, improving performance and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->