### PR TITLE
Improve logging and error handling for fetchRedirects function  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ yarn-error.log*
 # Deployment platforms
 
 .vercel
+.aider*

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -80,7 +80,9 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
     const writeDataRewrites = JSON.stringify(data.rewrites || [])
     await writeFile(rewritesFilename, writeDataRewrites)
 
-    console.log(`Fetch successful. Redirects count: ${data.redirects?.length || 0}, Rewrites count: ${data.rewrites?.length || 0}`)
+    console.log(
+      `Fetch successful. Redirects count: ${data.redirects?.length || 0}, Rewrites count: ${data.rewrites?.length || 0}`,
+    )
   } catch (e) {
     console.warn('Failed to fetch redirects:', e)
   }

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -80,8 +80,6 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
     const writeDataRewrites = JSON.stringify(data.rewrites || [])
     await writeFile(rewritesFilename, writeDataRewrites)
   } catch (e) {
-    // console.error('GraphQL Error', (e as Error).message)
-    // return false
   }
 
   return true

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -79,7 +79,10 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
 
     const writeDataRewrites = JSON.stringify(data.rewrites || [])
     await writeFile(rewritesFilename, writeDataRewrites)
+
+    console.log(`Fetch successful. Redirects count: ${data.redirects?.length || 0}, Rewrites count: ${data.rewrites?.length || 0}`)
   } catch (e) {
+    console.warn('Failed to fetch redirects:', e)
   }
 
   return true

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -27,8 +27,11 @@ export function getDefaultConfig(): TFetchRedirectsConfig {
 export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boolean> {
   const { graphqlEndpoint, graphqlApiKey, redirectsFilename, rewritesFilename, limit } = config
 
-  if (!graphqlEndpoint || !graphqlApiKey) {
-    throw new Error('Missing graphql configuration: NEXT_PUBLIC_GRAPHQL_URL or NEXT_API_TOKEN_ADMIN')
+  if (!graphqlEndpoint) {
+    console.warn('Warning: Missing graphql configuration: NEXT_PUBLIC_GRAPHQL_URL is empty')
+  }
+  if (!graphqlApiKey) {
+    console.warn('Warning: Missing graphql configuration: NEXT_API_TOKEN_ADMIN is empty')
   }
 
   if (!redirectsFilename || !rewritesFilename) {


### PR DESCRIPTION
## Issue Link

## Implementation details                                                                                  
 - [x] Add warning logs for empty graphqlEndpoint or graphqlApiKey                                          
 - [x] Implement logging for successful fetch of redirects and rewrites                                     
 - [x] Add error handling for failed fetch attempts             

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
 To test this PR:                                                                                           
                                                                                                            
 1. Set up your environment with different configurations:                                                  
    - With valid NEXT_PUBLIC_GRAPHQL_URL and NEXT_API_TOKEN_ADMIN                                           
    - With empty NEXT_PUBLIC_GRAPHQL_URL                                                                    
    - With empty NEXT_API_TOKEN_ADMIN                                                                       
    - With both empty                                                                                       
                                                                                                            
 2. Run the fetchRedirects function and observe the console output:                                         
    - You should see warnings when graphqlEndpoint or graphqlApiKey are empty                               
    - For successful fetches, you should see a log with the count of redirects and rewrites                 
    - For failed fetches, you should see a warning in the console                                           
                                                                                                            
 3. Check that the function continues to execute even when graphqlEndpoint or graphqlApiKey are empty, rath 
 than throwing an error                                                                                     
                                                                                                            
 4. Verify that the redirects.json and rewrites.json files are still created and populated when the fetch i 
 successful                                                                                                 
                                                                                                            
 This PR improves error handling and logging for the fetchRedirects function, providing better visibility   
 into the process without causing the task to fail completely when certain configurations are missing.      
                                                                                                        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to ignore files starting with "aider," improving file management.

- **Bug Fixes**
	- Enhanced error handling in the fetch redirects functionality, replacing abrupt failures with console warnings for missing configurations.
	- Improved logging for fetch operations, providing better visibility into redirect and rewrite counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->