### PR TITLE
fix(directus-node/automation): bundler module to es2015

### DIFF
--- a/libs/automation/tsconfig.json
+++ b/libs/automation/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "ES2015"
   },
   "files": [],
   "include": [],

--- a/libs/directus/directus-node/tsconfig.json
+++ b/libs/directus/directus-node/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2015",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/directus/directus-node/tsconfig.lib.json
+++ b/libs/directus/directus-node/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2015",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]


### PR DESCRIPTION
## Issue Link

## Implementation details
- [x] All projects should build

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Try running `npx nx run-many -t=build --projects=tag:publishable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated TypeScript configuration files to change module handling from CommonJS to ES2015, enhancing compatibility with modern JavaScript standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->