### PR TITLE
fix(directus-node): module to nextnode

### DIFF
--- a/libs/directus/directus-node/tsconfig.json
+++ b/libs/directus/directus-node/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/libs/directus/directus-node/tsconfig.lib.json
+++ b/libs/directus/directus-node/tsconfig.lib.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/libs/directus/directus-node/tsconfig.lib.json
+++ b/libs/directus/directus-node/tsconfig.lib.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]


### PR DESCRIPTION
## Implementation details
- [x] Directus Node project should have NodeNext module

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- try running `npx nx run-many -t=build --projects=tag:publishable` make sure every project is buildable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated TypeScript configuration to enhance module compilation and resolution strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->