### PR TITLE
CEP-590: Les images dans les blocs Wysiwyg ne s'affiche pas

### DIFF
--- a/libs/stack/stack-ui/.storybook/main.ts
+++ b/libs/stack/stack-ui/.storybook/main.ts
@@ -16,6 +16,7 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
+  staticDirs: ['../static'],
 }
 
 export default config

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
@@ -23,6 +23,7 @@ const WysiwygBlock = <T extends TToken>({ content, themeName = 'wysiwyg', ...res
         'width',
         'referrerpolicy',
       ],
+      img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
     },
   })
 

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
@@ -6,7 +6,7 @@ import type TWysiwygBlockProps from './interface'
 
 const WysiwygBlock = <T extends TToken>({ content, themeName = 'wysiwyg', ...rest }: TWysiwygBlockProps<T>) => {
   const sanitizedContent = sanitizeHtml(content, {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['iframe']),
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['iframe', 'img']),
     nonBooleanAttributes: [],
     allowedAttributes: {
       ...sanitizeHtml.defaults.allowedAttributes,

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.mdx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.mdx
@@ -56,3 +56,9 @@ export const Template = (args) => {
 <Canvas>
   <Story of={WysiwygStories.WebsiteWithScrolling} />
 </Canvas>
+
+### Wysiwyg Block with image tag
+
+<Canvas>
+  <Story of={WysiwygStories.WithImageTag} />
+</Canvas>

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.jsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.jsx
@@ -84,3 +84,12 @@ export const WebsiteWithScrolling = {
       '<iframe src="https://storybook.js.org/docs" title="storybook doc" height="600" width="600" marginwidth="50" scrolling="yes"></iframe>',
   },
 }
+
+export const WithImageTag = {
+  render: Template.bind({}),
+  name: 'With image tag',
+
+  args: {
+    content: '<img src="/images/image.png" alt="image" />',
+  },
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for rendering both `iframe` and `img` tags in the WysiwygBlock component.
	- Added a new showcase section in Storybook for the Wysiwyg Block, demonstrating usage with an image tag.
	- Created a new story, `WithImageTag`, to illustrate the WysiwygBlock component with an image element.

- **Documentation**
	- Enhanced Storybook documentation for the Wysiwyg Block component with a new example showcasing the use of an image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->