### PR TITLE
feat(directus-query): adding server side fallback for graphql endpoint

### DIFF
--- a/libs/directus/directus-query/README.md
+++ b/libs/directus/directus-query/README.md
@@ -28,3 +28,17 @@ const variables = {id: 1}
 const data = await queryClient.queryGql(DOCUMENT, variables)
 ```
 
+## Default Environment Variables
+Those environment variables are used in graphqlRequestClient (queryGql, useSuspenseGqlQuery) and graphqlRequestAdmin (useSuspenseGqlQueryAdmin)
+
+### Server/Client
+```
+NEXT_SERVER_GRAPHQL_URL=http://server.internal/graphql/ # server side only
+NEXT_PUBLIC_GRAPHQL_URL=https://server.okam.one/graphql/ # server fallback and client side
+NEXT_PUBLIC_API_TOKEN=abcdef
+```
+### Admin
+```
+NEXT_GRAPHQL_URL_ADMIN=http://server-admin.okam.one/graphql/ # server side only
+# admin request use the same token NEXT_PUBLIC_API_TOKEN
+```

--- a/libs/directus/directus-query/src/lib/request.tsx
+++ b/libs/directus/directus-query/src/lib/request.tsx
@@ -3,12 +3,25 @@
 import { QueryCache, QueryClient } from '@tanstack/react-query'
 import { GraphQLClient } from 'graphql-request'
 
-const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_GRAPHQL_URL as string
+const GRAPHQL_ENDPOINT_PUBLIC = process.env.NEXT_PUBLIC_GRAPHQL_URL as string
+const GRAPHQL_ENDPOINT_SERVER = process.env.NEXT_SERVER_GRAPHQL_URL as string
 const GRAPHQL_ENDPOINT_ADMIN = process.env.NEXT_GRAPHQL_URL_ADMIN as string
 const AUTH_TOKEN = (process.env.NEXT_PUBLIC_API_TOKEN as string) ?? ''
 const AUTH_TOKEN_ADMIN = process.env.NEXT_PUBLIC_API_TOKEN as string
 
-export const graphqlRequestClient = new GraphQLClient(GRAPHQL_ENDPOINT, {
+// for debugging, display default client endpoint
+export const grapqhlGetDefaultEndpoint = () => {
+  return GRAPHQL_ENDPOINT_SERVER || GRAPHQL_ENDPOINT_PUBLIC || ''
+}
+
+// for debugging, display admin client endpoint
+export const grapqhlGetDefaultAdminEndpoint = () => {
+  return GRAPHQL_ENDPOINT_ADMIN
+}
+
+// on server side, try to use NEXT_SERVER_GRAPHQL_URL (not public) and fallback on NEXT_PUBLIC_GRAPHQL_URL
+// on client side, use NEXT_PUBLIC_GRAPHQL_URL because NEXT_SERVER_GRAPHQL_URL should be undefined
+export const graphqlRequestClient = new GraphQLClient(GRAPHQL_ENDPOINT_SERVER || GRAPHQL_ENDPOINT_PUBLIC, {
   credentials: 'include',
   mode: 'cors',
   fetch,


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/CEP-679

## Implementation details
- [ ] Use NEXT_SERVER_GRAPHQL_URL
- [ ] Fallback on NEXT_PUBLIC_GRAPHQL_URL

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Should be able to use NEXT_SERVER_GRAPHQL_URL and NEXT_PUBLIC_GRAPHQL_URL on server/client mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `directus-query` library documentation to include a new section on default environment variables for GraphQL requests.
	- Detailed environment variables for "Server/Client" and "Admin" contexts.

- **New Features**
	- Introduced new constants for public and server-specific GraphQL endpoints.
	- Added fallback mechanism for selecting the appropriate GraphQL endpoint based on the environment.
	- Implemented new debugging functions for accessing default endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->