### PR TITLE
fix: add missing typins to packages

### DIFF
--- a/libs/stack/core-lib/package.json
+++ b/libs/stack/core-lib/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@okam/core-lib",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "./index.js",
   "types": "./index.d.ts",
   "license": "MIT",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
     }
   },
   "publishConfig": {

--- a/libs/stack/logger/package.json
+++ b/libs/stack/logger/package.json
@@ -1,15 +1,22 @@
 {
   "name": "@okam/logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
+  "license": "BUSL-1.1",
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "type": "commonjs",
-  "main": "./src/index.js",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Issue Link

## Implementation details
- [x] fix typings in packages

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- import package in a different project. check if package import includes types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versioning for `@okam/core-lib` to 1.15.1 and `@okam/logger` to 1.0.1.
	- Added license information for `@okam/logger`.
	- Introduced TypeScript declaration files for both packages.

- **Improvements**
	- Enhanced export structure for better module resolution and type definitions in both packages.
	- Restructured main entry point for `@okam/logger`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->