### PR TITLE
STACK-238-Select-field-Value-should-be-typed-to-nullable-string

### DIFF
--- a/libs/stack/stack-ui/src/components/fields/Select/Select.interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.interface.ts
@@ -2,7 +2,7 @@ import type { Key } from 'react'
 import type React from 'react'
 import type { RefCallBack } from 'react-hook-form'
 import type { TToken } from '../../../providers/Theme/interface'
-import type { TDefaultComponent, TReactHookForm } from '../../../types/components'
+import type { TDefaultComponent, TReactHookForm, Nullable } from '../../../types/components'
 
 export type TFieldReactHookForm<T = TToken> = TReactHookForm & Omit<TDefaultComponent<T>, 'children'>
 export interface TSelectProps<T = TToken> extends TFieldReactHookForm<T> {
@@ -18,7 +18,7 @@ export interface TSelectProps<T = TToken> extends TFieldReactHookForm<T> {
   placeholderLabel: string
   hookFormRef?: RefCallBack
   onSelectionChange?: (value: Key) => void
-  defaultValue?: string
+  defaultValue?: Nullable<string>
   value?: string
   popoverMatchesWidth?: boolean
   options?: { key: string; value: string }[]

--- a/libs/stack/stack-ui/src/components/fields/Select/Select.interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.interface.ts
@@ -18,8 +18,8 @@ export interface TSelectProps<T = TToken> extends TFieldReactHookForm<T> {
   placeholderLabel: string
   hookFormRef?: RefCallBack
   onSelectionChange?: (value: Key) => void
-  defaultValue?: Nullable<string>
-  value?: string
+  defaultValue?: string
+  value?: Nullable<string>
   popoverMatchesWidth?: boolean
   options?: { key: string; value: string }[]
 }

--- a/libs/stack/stack-ui/src/storybook/SelectField/index.tsx
+++ b/libs/stack/stack-ui/src/storybook/SelectField/index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
+import Box from '../../components/Box'
 import Select from '../../components/fields/Select/Select'
 import type { TSelectProps } from '../../components/fields/Select/Select.interface'
+import type { Nullable } from '../../types/components'
 
 const SelectContent = ({
   disabled = false,
@@ -12,22 +14,29 @@ const SelectContent = ({
   placeholderLabel,
   ...rest
 }: TSelectProps) => {
-  const [value, setValue] = useState<string>()
+  const [value, setValue] = useState<Nullable<string>>()
 
   return (
     <>
-      <button type="button" onClick={() => setValue('1')}>
-        1
-      </button>
-      <button type="button" onClick={() => setValue('2')}>
-        2
-      </button>
-      <button type="button" onClick={() => setValue('3')}>
-        3
-      </button>
-      <button type="button" onClick={() => setValue('4')}>
-        4
-      </button>
+      <Box>
+        <button type="button" onClick={() => setValue(null)}>
+          Set back to no value
+        </button>
+      </Box>
+      <Box>
+        <button type="button" onClick={() => setValue('1')}>
+          1
+        </button>
+        <button type="button" onClick={() => setValue('2')}>
+          2
+        </button>
+        <button type="button" onClick={() => setValue('3')}>
+          3
+        </button>
+        <button type="button" onClick={() => setValue('4')}>
+          4
+        </button>
+      </Box>
       <Select
         id={id}
         label={label}


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-238

## Implementation details
- [x] Value prop in Select component should be nullable

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Clicking on the "Set back to no value" button in Select stories should set back the select's value to null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Select component to support nullable default values, providing more flexibility in handling default selections.
	- Improved user interface by restructuring buttons for better organization and adding a clear selection option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->