### PR TITLE
feat(directus-node): adding read/write functions for redirections

### DIFF
--- a/libs/directus/directus-next/src/lib/directusRouteRouter.ts
+++ b/libs/directus/directus-next/src/lib/directusRouteRouter.ts
@@ -20,8 +20,12 @@ async function fetchPageSettingsTranslation(path: string): Promise<PageSettingsT
   const graphqlEndpoint = process.env.NEXT_SERVER_GRAPHQL_URL || process.env.NEXT_PUBLIC_GRAPHQL_URL
   const graphqlApiKey = process.env.NEXT_PUBLIC_API_TOKEN
 
-  if (!graphqlEndpoint || !graphqlApiKey) {
-    throw new Error('Missing GraphQL configuration')
+  if (!graphqlEndpoint) {
+    throw new Error('Missing GraphQL configuration `graphqlEndpoint`')
+  }
+
+  if (!graphqlApiKey) {
+    throw new Error('Missing GraphQL configuration `graphqlApiKey`')
   }
 
   const query = `

--- a/libs/directus/directus-node/README.md
+++ b/libs/directus/directus-node/README.md
@@ -70,7 +70,7 @@ export const rewrites = async () => rewritesData
 
 5. Define environments variables
 ```
-NEXT_SERVER_GRAPHQL_URL=http://server.internal/graphql
+NEXT_REDIRECT_GRAPHQL_URL=http://server.some.url/graphql
 NEXT_PUBLIC_GRAPHQL_URL=https://server.external/graphql
 NEXT_API_TOKEN_ADMIN=user_token_for_graphql
 ```

--- a/libs/directus/directus-node/src/lib/__tests__/redirection.test.ts
+++ b/libs/directus/directus-node/src/lib/__tests__/redirection.test.ts
@@ -1,5 +1,5 @@
 // Usage: pnpm nx test directus-node
-// add NEXT_SERVER_GRAPHQL_URL and NEXT_API_TOKEN_ADMIN to your .env
+// add NEXT_REDIRECT_GRAPHQL_URL and NEXT_API_TOKEN_ADMIN to your .env
 
 import { fetchRedirects, fetchRedirectsData, getDefaultConfig, readRedirectFile, redirectDefaultLimit, writeRedirectFile } from '../redirection'
 

--- a/libs/directus/directus-node/src/lib/__tests__/redirection.test.ts
+++ b/libs/directus/directus-node/src/lib/__tests__/redirection.test.ts
@@ -1,0 +1,66 @@
+// Usage: pnpm nx test directus-node
+// add NEXT_SERVER_GRAPHQL_URL and NEXT_API_TOKEN_ADMIN to your .env
+
+import { fetchRedirects, fetchRedirectsData, getDefaultConfig, readRedirectFile, redirectDefaultLimit, writeRedirectFile } from '../redirection'
+
+// write/read in coverage, tmp or dist ?
+const redirectsFilename = 'dist/directus-node-redirects.test.json'
+const rewritesFilename = 'dist/directus-node-rewrites.test.json'
+
+describe('checking constants and config', () => {
+  test('redirectDefaultLimit is 2000', () => {
+    expect(redirectDefaultLimit).toBe(2000)
+  })
+
+  test('getDefaultConfig returns a default configuration object', () => {
+    const config = getDefaultConfig()
+    expect(config.limit).toBe(2000)
+    expect(config.redirectsFilename).toBe('./redirect/redirects.json')
+    expect(config).toHaveProperty('graphqlEndpoint')
+    expect(config).toHaveProperty('graphqlApiKey')
+    expect(config).toHaveProperty('rewritesFilename')
+  })
+})
+
+describe('fetching data', () => {
+  test('fetchRedirectsData returns data, using default .env config', async () => {
+    const config = getDefaultConfig()
+    const data = await fetchRedirectsData(config)
+    expect(Array.isArray(data.redirects)).toBe(true)
+    expect(Array.isArray(data.rewrites)).toBe(true)
+    expect(fetchRedirectsData({
+      graphqlEndpoint: '',
+      graphqlApiKey: '',
+      limit: 0,
+    })).rejects.toThrow()
+  })
+})
+
+describe('writing / reading file', () => {
+  test('writeRedirectFile', async () => {
+    const data = [
+      {source:'a', destination: 'b'},
+    ]
+
+    await expect(writeRedirectFile(redirectsFilename, data)).resolves.toBe(true)
+  })
+
+  test('readRedirectFile', async () => {
+    const data = await readRedirectFile(redirectsFilename, 'redirects')
+    expect(data.length).toBe(1)
+    expect(data[0].source).toBe('a')
+  })
+})
+
+describe('Fetch redirect main function', () => {
+  test('fetchRedirect with dist/ output', async () => {
+    const config = {
+      ...getDefaultConfig(),
+      redirectsFilename,
+      rewritesFilename,
+      limit: 10,
+    }
+
+    await expect(fetchRedirects(config)).resolves.toBe(true)
+  })
+})

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -1,14 +1,28 @@
-import { writeFile } from 'node:fs/promises'
-import { logger } from '@okam/logger'
-import { log } from '../logger'
+import { writeFile, readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { logger } from '../logger'
 
 interface TFetchRedirectsConfig {
   graphqlEndpoint: string
   graphqlApiKey: string
-  redirectsFilename: string
-  rewritesFilename: string
+  redirectsFilename?: string
+  rewritesFilename?: string
   limit: number | undefined
 }
+
+interface TFetchRedirectsResponse {
+  redirects: unknown
+  rewrites: unknown
+}
+
+interface TRedirectData {
+  source: string
+  destination: string
+  permanent?: boolean
+  locale?: boolean
+}
+
+type TRedirectType = 'redirects' | 'rewrites'
 
 export const redirectDefaultLimit = 2000
 
@@ -18,7 +32,7 @@ export const redirectDefaultLimit = 2000
  */
 export function getDefaultConfig(): TFetchRedirectsConfig {
   return {
-    graphqlEndpoint: process.env['NEXT_PUBLIC_GRAPHQL_URL'] || '',
+    graphqlEndpoint: process.env['NEXT_SERVER_GRAPHQL_URL'] || process.env['NEXT_PUBLIC_GRAPHQL_URL'] || '',
     graphqlApiKey: process.env['NEXT_API_TOKEN_ADMIN'] || '',
     redirectsFilename: './redirect/redirects.json',
     rewritesFilename: './redirect/rewrites.json',
@@ -26,15 +40,18 @@ export function getDefaultConfig(): TFetchRedirectsConfig {
   }
 }
 
-export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boolean> {
-  const { graphqlEndpoint, graphqlApiKey, redirectsFilename, rewritesFilename, limit } = config
+export async function fetchRedirectsData(config: TFetchRedirectsConfig): Promise<TFetchRedirectsResponse> {
+  const { graphqlEndpoint, graphqlApiKey, limit } = config
 
-  if (!graphqlEndpoint || !graphqlApiKey) {
-    throw new Error('Missing graphql configuration: NEXT_PUBLIC_GRAPHQL_URL or NEXT_API_TOKEN_ADMIN')
+  if (!graphqlEndpoint) {
+    throw new Error(
+      'Missing fetchRedirects configuration `graphqlEndpoint`. Check environment variables NEXT_SERVER_GRAPHQL_URL or NEXT_PUBLIC_GRAPHQL_URL',
+    )
   }
-
-  if (!redirectsFilename || !rewritesFilename) {
-    throw new Error('Missing filename')
+  if (!graphqlApiKey) {
+    throw new Error(
+      'Missing fetchRedirects configuration `graphqlApiKey`. Check environment variable NEXT_API_TOKEN_ADMIN',
+    )
   }
 
   const query = `query fetchRedirects($limit: Int = 2000) {
@@ -73,17 +90,90 @@ export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boo
     })
     const { data } = await response.json()
 
-    const writeDataRedirects = JSON.stringify(data.redirects || [])
-    await writeFile(redirectsFilename, writeDataRedirects)
-
-    const writeDataRewrites = JSON.stringify(data.rewrites || [])
-    await writeFile(rewritesFilename, writeDataRewrites)
-
-    log(`Redirects count: ${data.redirects?.length || 0}, Rewrites count: ${data.rewrites?.length || 0}`)
+    logger.log(`Fetch redirects count: ${data.redirects?.length || 0}, rewrites count: ${data.rewrites?.length || 0}`)
+    return {
+      redirects: data.redirects || [],
+      rewrites: data.rewrites || [],
+    }
   } catch (e) {
-    log(`Error fetching redirects: ${(e as Error).message}`, 'error')
-    return true // still want build to pass
+    logger.log(`Error fetching redirects: ${(e as Error).message}`, 'error')
+  }
+  return {
+    redirects: [],
+    rewrites: [],
+  }
+}
+
+/**
+ * Write Redirect Data
+ * @param {string} filename filename
+ * @param {unknown} data redirects data (rewrites or redirects)
+ */
+export async function writeRedirectFile(filename: string, data: unknown): Promise<boolean> {
+  try {
+    const writeData = JSON.stringify(data || [])
+    await writeFile(filename, writeData)
+    return true
+  } catch (e) {
+    logger.log(`Error writing redirect file ${filename}: ${(e as Error).message}`, 'error')
+  }
+  return false
+}
+
+export async function readRedirectFileData(filename: string): Promise<unknown> {
+  try {
+    const file = await readFile(filename, { encoding: 'utf8' })
+    const data = JSON.parse(file)
+    return data
+  } catch (e) {
+    logger.log(`Failed loading redirects JSON from ${filename}: ${(e as Error).message}`, 'error')
+  }
+  return []
+}
+
+/**
+ * Read one redirects or rewrites file
+ * @param {string} filePath relative file path like './redirect/redirects.json' to the current working dir
+ * @param {TRedirectType} type redirects or rewrites
+ * @returns {Promise<TRedirectData[]>} an array of redirect information
+ */
+export async function readRedirectFile(filePath: string, type: TRedirectType = 'redirects'): Promise<TRedirectData[]> {
+  const absolutePath = path.resolve(process.cwd(), filePath)
+  const data = await readRedirectFileData(absolutePath)
+  if (Array.isArray(data)) {
+    // check data integrity
+    const checkedData = data.filter((x) => {
+      return x && typeof x?.source === 'string' && typeof x?.destination === 'string'
+    })
+    logger.log(`Loading ${type} length: ${checkedData.length}`)
+    return checkedData
+  }
+  logger.log(`Failed loading ${type}, not a valid array`, 'error')
+  return [] as TRedirectData[]
+}
+
+/**
+ * Fetch and write redirects and rewrites files
+ * @param {TFetchRedirectsConfig} config fetch redirects configuration
+ * @returns {Promise<boolean>} true
+ * @throws {Error}
+ */
+export async function fetchRedirects(config: TFetchRedirectsConfig): Promise<boolean> {
+  const { redirectsFilename, rewritesFilename } = config
+
+  if (!redirectsFilename) {
+    throw new Error('Missing fetchRedirects configuration `redirectsFilename`')
   }
 
+  if (!rewritesFilename) {
+    throw new Error('Missing fetchRedirects configuration `rewritesFilename`')
+  }
+
+  // fetch can throw
+  const data = await fetchRedirectsData(config)
+
+  // should not throw
+  await writeRedirectFile(redirectsFilename, data.redirects)
+  await writeRedirectFile(rewritesFilename, data.rewrites)
   return true
 }

--- a/libs/directus/directus-node/src/lib/redirection.ts
+++ b/libs/directus/directus-node/src/lib/redirection.ts
@@ -32,7 +32,7 @@ export const redirectDefaultLimit = 2000
  */
 export function getDefaultConfig(): TFetchRedirectsConfig {
   return {
-    graphqlEndpoint: process.env['NEXT_SERVER_GRAPHQL_URL'] || process.env['NEXT_PUBLIC_GRAPHQL_URL'] || '',
+    graphqlEndpoint: process.env['NEXT_REDIRECT_GRAPHQL_URL'] || process.env['NEXT_PUBLIC_GRAPHQL_URL'] || '',
     graphqlApiKey: process.env['NEXT_API_TOKEN_ADMIN'] || '',
     redirectsFilename: './redirect/redirects.json',
     rewritesFilename: './redirect/rewrites.json',
@@ -45,7 +45,7 @@ export async function fetchRedirectsData(config: TFetchRedirectsConfig): Promise
 
   if (!graphqlEndpoint) {
     throw new Error(
-      'Missing fetchRedirects configuration `graphqlEndpoint`. Check environment variables NEXT_SERVER_GRAPHQL_URL or NEXT_PUBLIC_GRAPHQL_URL',
+      'Missing fetchRedirects configuration `graphqlEndpoint`. Check environment variables NEXT_REDIRECT_GRAPHQL_URL or NEXT_PUBLIC_GRAPHQL_URL',
     )
   }
   if (!graphqlApiKey) {

--- a/libs/directus/directus-node/src/logger.ts
+++ b/libs/directus/directus-node/src/logger.ts
@@ -1,5 +1,3 @@
 import { createLogger } from '@okam/logger'
 
 export const logger = createLogger('[DirectusNode]')
-
-export const { log } = logger


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-248

## Implementation details
- [ ] Separate fetch/read/write/json parsing for redirections
- [ ] Adding unit tests
- [ ] Fix logger.log issue (not binded)
- [ ] Adding ESM code example

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- pnpm nx test directus-node
- it should write files in dist/

## Not sure
- reading/writing in dist/  (without creating it first) in the tests
- NEXT_SERVER_GRAPHQL_URL was replaced by NEXT_REDIRECT_GRAPHQL_URL instead


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for handling redirects and rewrites using ES module syntax.
	- Enhanced configuration options with new environment variables for GraphQL endpoints and tokens.
	
- **Bug Fixes**
	- Improved error handling with specific messages for missing configuration parameters.

- **Tests**
	- Added comprehensive unit tests for redirection functionality in the Directus Node library, covering various aspects including constants, configuration, data fetching, and file operations.

- **Chores**
	- Modified logger export configuration, removing direct `log` method export.

These changes enhance the library's functionality, improve error reporting, and increase testing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->