### PR TITLE
Stack 252 use block should accept a client options param

### DIFF
--- a/libs/directus/directus-block/README.md
+++ b/libs/directus/directus-block/README.md
@@ -41,6 +41,12 @@ This component calls the good component in the configuration from the `collectio
 - variables: The block's variables. Passing the id is necessary
 - document: Can also be passed in the config. The document that will be used to make a query
 
+#### `useBlock` function
+
+The `useBlock` function is a hook that automatically determines wether a block should use `props.item` (passed props) or `props.variables` (makes its own query).
+
+If `props.item` only contains `id` and `settings`, the item will be determined to be empty, and the block will still make the query using `props.variables`.
+
 ## Configuration
 
 A configuration uses the `components` prop to map a key value, like so:

--- a/libs/directus/directus-block/src/hooks/useBlock.tsx
+++ b/libs/directus/directus-block/src/hooks/useBlock.tsx
@@ -1,26 +1,64 @@
+import { defaultGraphqlRequestClient } from '@okam/directus-query'
 import type { Nullable, TToken } from '@okam/stack-ui'
 import type { TypedQueryDocumentNode } from 'graphql'
+import type { GraphQLClient } from 'graphql-request'
 import { get } from 'radashi'
 import type { TBlockSerializerProps } from '../components/BlockSerializer/interface'
 import { BlockSettingsFragmentDoc } from '../generated/graphql'
 import type { TBlockQuery, TBlockVariables, TCommonBlockFragment } from '../types/block'
 import { getBlockProps, getFragment } from '../utils'
 
+function isClient<T extends TCommonBlockFragment>(
+  docOrClient: Nullable<TypedQueryDocumentNode<TBlockQuery<T>, TBlockVariables> | GraphQLClient>,
+) {
+  return typeof docOrClient === 'function'
+}
+
+/**
+ * Automatically determines wether a block should use `props.item` (passed props) or `props.variables` (makes its own query).
+ * @param props Props of the block/block query. `props.item` serves as props the block uses directly, where as `props.variables` serves as variables for the block query.
+ * @param blockKey Key of the block query that serves to return the contents of the block directly, removing one step
+ * @param docOrClient Client to pass to `queryGql`. Defaults to `defaultGraphqlRequestClient`. **Deprecated**: can also be a fallback for `props.document`.
+ * @returns Contents of `blockKey` in the query. Also returns `settings.tokens` as `cmsTokens` for convenience.
+ */
 async function useBlock<T extends TCommonBlockFragment>(
   props: TBlockSerializerProps<T>,
   blockKey: string,
+  /**
+   * @default defaultGraphqlRequestClient
+   */
+  client?: GraphQLClient,
+): Promise<T & { cmsTokens: TToken }>
+
+async function useBlock<T extends TCommonBlockFragment>(
+  props: TBlockSerializerProps<T>,
+  blockKey: string,
+  /**
+   * @deprecated Use props.document instead
+   */
   doc?: TypedQueryDocumentNode<TBlockQuery<T>, TBlockVariables>,
+): Promise<T & { cmsTokens: TToken }>
+
+async function useBlock<T extends TCommonBlockFragment>(
+  props: TBlockSerializerProps<T>,
+  blockKey: string,
+  docOrClient: TypedQueryDocumentNode<TBlockQuery<T>, TBlockVariables> | GraphQLClient = defaultGraphqlRequestClient,
 ): Promise<T & { cmsTokens: TToken }> {
   const item = get<Nullable<TCommonBlockFragment>>(props, 'item')
-  const document = doc ?? get<TypedQueryDocumentNode<TBlockQuery<T>, TBlockVariables>>(props, 'document')
+  const isPropClient = isClient(docOrClient)
+
+  const document = get<TypedQueryDocumentNode<TBlockQuery<T>, TBlockVariables>>(props, 'document')
   const variables = get<TBlockVariables<TBlockVariables>>(props, 'variables')
 
-  const propsWithFallback = await getBlockProps({
-    item,
-    blockKey,
-    document,
-    variables,
-  })
+  const propsWithFallback = await getBlockProps(
+    {
+      item,
+      blockKey,
+      document: document ?? (!isPropClient ? docOrClient : undefined),
+      variables,
+    },
+    isPropClient ? docOrClient : undefined,
+  )
 
   const { tokens } = getFragment(BlockSettingsFragmentDoc, propsWithFallback?.settings) ?? {}
   return { ...(propsWithFallback as T), cmsTokens: tokens }

--- a/libs/directus/directus-block/src/utils/get-block-props.ts
+++ b/libs/directus/directus-block/src/utils/get-block-props.ts
@@ -1,6 +1,6 @@
 'server-only'
 
-import { queryGql } from '@okam/directus-query'
+import { queryGql, defaultGraphqlRequestClient } from '@okam/directus-query'
 import type { Nullable } from '@okam/stack-ui'
 import type { Variables } from 'graphql-request'
 import { isEmpty } from 'radashi'
@@ -31,12 +31,12 @@ function isItemEmpty(item: TCommonBlockFragment): item is TBlockVariables {
 async function queryFromVariables<
   BlockFragment extends TCommonBlockFragment,
   BlockVariables extends Variables = Variables,
->(params: TGetBlockPropsParams<BlockFragment, BlockVariables>) {
+>(params: TGetBlockPropsParams<BlockFragment, BlockVariables>, client = defaultGraphqlRequestClient) {
   const { document, blockKey, variables } = params
 
   if (!document || !isVariables<BlockVariables>(variables)) return null
 
-  const queriedBlockProps = await queryGql(document, variables)
+  const queriedBlockProps = await queryGql(document, variables, client)
 
   if (!queriedBlockProps || typeof queriedBlockProps !== 'object' || !blockKey) return null
 
@@ -49,12 +49,16 @@ async function queryFromVariables<
  * Returns the passed item if it is defined. Otherwise, queried its own block
  * @param params.blockKey Key of the queried field
  * @param params.item Item of the block. If null or only contains the block's id, the function will make a query
+ * @param client Client to pass to `queryGql`. Defaults to `defaultGraphqlRequestClient`.
  * @returns The block data
  */
 export default async function getBlockProps<
   BlockFragment extends TCommonBlockFragment,
   BlockVariables extends Variables = Variables,
->(params: TGetBlockPropsParams<BlockFragment, BlockVariables>): Promise<BlockFragment | null | undefined> {
+>(
+  params: TGetBlockPropsParams<BlockFragment, BlockVariables>,
+  client = defaultGraphqlRequestClient,
+): Promise<BlockFragment | null | undefined> {
   const { document, item, blockKey, variables } = params
 
   if (item) {
@@ -76,7 +80,7 @@ export default async function getBlockProps<
 
   if (!document || !isVariables(variables)) return null
 
-  const queriedBlockProps = await queryGql(document, variables)
+  const queriedBlockProps = await queryGql(document, variables, client)
 
   if (!queriedBlockProps || typeof queriedBlockProps !== 'object' || !blockKey) return null
 

--- a/libs/directus/directus-query/src/index.ts
+++ b/libs/directus/directus-query/src/index.ts
@@ -2,3 +2,7 @@ export * from './lib/hooks'
 export * from './lib/query'
 export { logger as DirectusQueryLogger } from './logger'
 export { default as initDirectusQuery } from './lib/init'
+export {
+  graphqlRequestClient as defaultGraphqlRequestClient,
+  graphqlRequestAdmin as defaultGraphqlRequestAdmin,
+} from './lib/request'

--- a/libs/directus/directus-query/src/server.ts
+++ b/libs/directus/directus-query/src/server.ts
@@ -1,3 +1,7 @@
 export * from './lib/query'
 export { default as initDirectusQuery } from './lib/init'
 export { logger as DirectusQueryLogger } from './logger'
+export {
+  graphqlRequestClient as defaultGraphqlRequestClient,
+  graphqlRequestAdmin as defaultGraphqlRequestAdmin,
+} from './lib/request'


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-252

## Implementation details
- [ ] `useBlock` should support getting passed a query client
- [ ] Old `useBlock` parameters should still work for legacy projects

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Demo
- /directus-block
