### PR TITLE
STACK-256 Allowed attributes / tags control for wysiwyg block

### DIFF
--- a/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/index.tsx
@@ -4,27 +4,42 @@ import Typography from '../Typography'
 import { ariaAttributes, booleanAttributes } from './attributes'
 import type TWysiwygBlockProps from './interface'
 
-const WysiwygBlock = <T extends TToken>({ content, themeName = 'wysiwyg', ...rest }: TWysiwygBlockProps<T>) => {
+const defaultAllowedTags = ['iframe', 'img']
+const defaultAllowedAttributes = {
+  iframe: [
+    'src',
+    'allow',
+    'allowfullscreen',
+    'frameborder',
+    'scrolling',
+    'target',
+    'title',
+    'height',
+    'width',
+    'referrerpolicy',
+  ],
+  img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
+}
+
+const WysiwygBlock = <Tags extends string = string, T extends TToken = TToken>({
+  content,
+  themeName = 'wysiwyg',
+  useSanitizerDefaultAllowedTags = true,
+  useSanitizerDefaultAllowedAttributes = true,
+  allowedTags = defaultAllowedTags as Tags[],
+  allowedAttributes = defaultAllowedAttributes as Partial<Record<Tags, string[]>>,
+  ...rest
+}: TWysiwygBlockProps<Tags, T>) => {
   const sanitizedContent = sanitizeHtml(content, {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['iframe', 'img']),
+    allowedTags: useSanitizerDefaultAllowedTags ? sanitizeHtml.defaults.allowedTags.concat(allowedTags) : allowedTags,
     nonBooleanAttributes: [],
-    allowedAttributes: {
-      ...sanitizeHtml.defaults.allowedAttributes,
-      '*': [...sanitizeHtml.defaults.nonBooleanAttributes, ...ariaAttributes, ...booleanAttributes],
-      iframe: [
-        'src',
-        'allow',
-        'allowfullscreen',
-        'frameborder',
-        'scrolling',
-        'target',
-        'title',
-        'height',
-        'width',
-        'referrerpolicy',
-      ],
-      img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading'],
-    },
+    allowedAttributes: useSanitizerDefaultAllowedAttributes
+      ? {
+          ...sanitizeHtml.defaults.allowedAttributes,
+          '*': [...sanitizeHtml.defaults.nonBooleanAttributes, ...ariaAttributes, ...booleanAttributes],
+          ...allowedAttributes,
+        }
+      : (allowedAttributes as Record<string, string[]>),
   })
 
   return (

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/interface.ts
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/interface.ts
@@ -1,8 +1,13 @@
 import type { TToken } from '../../providers/Theme/interface'
 import type { TDefaultComponent } from '../../types/components'
 
-interface TWysiwygBlockProps<T = TToken> extends TDefaultComponent<T> {
+interface TWysiwygBlockProps<Tags extends string = string, T = TToken> extends TDefaultComponent<T> {
   content: string
+  useSanitizerDefaultAllowedTags?: boolean
+  useSanitizerDefaultAllowedAttributes?: boolean
+  allowedTags?: Tags[]
+  allowedAttributes?: {
+    [K in Tags]?: string[]
+  }
 }
-
 export default TWysiwygBlockProps

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.mdx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.mdx
@@ -1,64 +1,18 @@
-import { Canvas, Meta, Story } from '@storybook/blocks'
-import { ArgTypes } from '@storybook/blocks'
-import WysiwygBlock from './'
-import * as WysiwygStories from './wysiwyg.stories';
+import { Canvas, Meta, Story, Stories, ArgTypes, Description } from '@storybook/blocks'
+import * as WysiwygStories from './wysiwyg.stories'
 
 <Meta of={WysiwygStories} />
 
-export const Template = (args) => {
-  return <WysiwygBlock {...args} />
-}
-
 # Wysiwyg Block
+
+<Description of={WysiwygStories} />
 
 #### Wysiwyg Block. Can be used in CMS to insert HTML elements as text with certain attributes (h1, h2, h3, link with target, etc.)
 
 ## Props
 
-<ArgTypes />
+<ArgTypes of={WysiwygStories} />
 
-## Showcase
+## All Stories
 
-### Wysiwyg Block link with target \_self
-
-<Canvas>
-  <Story of={WysiwygStories.LinkWithTargetSelf} />
-</Canvas>
-
-### Wysiwyg Block link with target \_blank
-
-<Canvas>
-  <Story of={WysiwygStories.LinkWithTargetBlank} />
-</Canvas>
-
-### Wysiwyg Block with tailwind styles
-
-<Canvas>
-  <Story of={WysiwygStories.WithTailwindStyles} />
-</Canvas>
-
-### Wysiwyg Block with style tag
-
-<Canvas>
-  <Story of={WysiwygStories.WithStyleTag} />
-</Canvas>
-
-### Wysiwyg Block with aria attributes
-
-<Canvas>
-  <Story of={WysiwygStories.WithAriaAttributes} />
-</Canvas>
-
-<Canvas>
-  <Story of={WysiwygStories.YoutubeEmbedVideoIframe} />
-</Canvas>
-
-<Canvas>
-  <Story of={WysiwygStories.WebsiteWithScrolling} />
-</Canvas>
-
-### Wysiwyg Block with image tag
-
-<Canvas>
-  <Story of={WysiwygStories.WithImageTag} />
-</Canvas>
+<Stories />

--- a/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.jsx
+++ b/libs/stack/stack-ui/src/components/WysiwygBlock/wysiwyg.stories.jsx
@@ -1,95 +1,138 @@
 import WysiwygBlock from '.'
 
-const Template = (args) => {
-  return <WysiwygBlock {...args} />
-}
+// Define the Template component
+const Template = (args) => <WysiwygBlock {...args} />
 
+// Default export with component metadata
 export default {
   title: 'BASE COMPONENTS/Wysiwyg Block',
   component: WysiwygBlock,
-
   argTypes: {
     content: {
       description: 'Takes HTML elements in string form from the Wysiwyg block content',
     },
-
     WysiwygBlockAttributes: {
       description: 'target, allow, allowfullscreen, frameborder, scrolling, iframe',
     },
   },
-
-  args: {
-    content: '<a target="_self" href="https://www.google.com/">Link with target _self</a>',
+  parameters: {
+    docs: {
+      description: {
+        component: 'Wysiwyg Block component for rendering sanitized HTML content',
+      },
+    },
   },
 }
 
-export const LinkWithTargetSelf = {
-  render: Template.bind({}),
-  name: 'Link with target _self',
+// Individual story exports
+export const LinkWithTargetSelf = Template.bind({})
+LinkWithTargetSelf.args = {
+  content: '<a target="_self" href="https://www.google.com/">Link with target _self</a>',
 }
+LinkWithTargetSelf.storyName = 'Link with target _self'
 
-export const LinkWithTargetBlank = {
-  render: Template.bind({}),
-  name: 'Link with target blank',
+export const LinkWithTargetBlank = Template.bind({})
+LinkWithTargetBlank.args = {
+  content: '<a target="_blank" href="https://www.google.com/">Link with target _blank</a>',
+}
+LinkWithTargetBlank.storyName = 'Link with target blank'
 
-  args: {
-    content: '<a target="_blank" href="https://www.google.com/">Link with target _blank</a>',
+export const WithTailwindStyles = Template.bind({})
+WithTailwindStyles.args = {
+  content: '<div class="bg-color-1-300"><h1 class="text-5xl">Title</h1></div>',
+}
+WithTailwindStyles.storyName = 'With Tailwind styles'
+
+export const WithStyleTag = Template.bind({})
+WithStyleTag.args = {
+  content: '<div style="background-color: red;"><h1 style="font-size: 3rem;">Title</h1></div>',
+}
+WithStyleTag.storyName = 'With style tag'
+
+export const WithAriaAttributes = Template.bind({})
+WithAriaAttributes.args = {
+  content: `
+    <a class="bg-color-1-300 disabled:opacity-50" href="#" disabled aria-label="I am a disabled link">Accessible link</a>
+  `,
+}
+WithAriaAttributes.storyName = 'With aria attributes'
+
+export const YoutubeEmbedVideoIframe = Template.bind({})
+YoutubeEmbedVideoIframe.args = {
+  content: `
+    <p>Attributes of iframe : width, height, src, title, frameborder, allow, referrerpolicy, allowfullscreen</p>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/p-LFh5Y89eM?si=kTfC2QRi646JaaeK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  `,
+}
+YoutubeEmbedVideoIframe.storyName = 'Youtube embed video iframe'
+
+export const WebsiteWithScrolling = Template.bind({})
+WebsiteWithScrolling.args = {
+  content: `
+    <iframe src="https://storybook.js.org/docs" title="storybook doc" height="600" width="600" marginwidth="50" scrolling="yes"></iframe>
+  `,
+}
+WebsiteWithScrolling.storyName = 'Website with scrolling'
+
+export const WithImageTag = Template.bind({})
+WithImageTag.args = {
+  content: '<img src="/images/image.png" alt="image" />',
+}
+WithImageTag.storyName = 'With image tag'
+
+// Examples demonstrating different configurations of allowed tags and attributes
+export const WithDefaultAllowedTagsAndAttributes = Template.bind({})
+WithDefaultAllowedTagsAndAttributes.args = {
+  content: `
+    <p>This example uses the default allowed tags and attributes.</p>
+    <iframe 
+      src="https://www.youtube.com/embed/p-LFh5Y89eM" 
+      width="560" 
+      height="315" 
+      allowfullscreen
+      title="YouTube video player">
+    </iframe>
+    <p>The component allows <code>iframe</code> and <code>img</code> tags by default, along with their common attributes.</p>
+  `,
+  useSanitizerDefaultAllowedTags: true,
+  useSanitizerDefaultAllowedAttributes: true,
+}
+WithDefaultAllowedTagsAndAttributes.storyName = 'With Default Allowed Tags and Attributes'
+
+export const WithExtendedAllowedTagsAndAttributes = Template.bind({})
+WithExtendedAllowedTagsAndAttributes.args = {
+  content: `
+    <p>This example extends the default allowed tags and attributes to include <code>video</code> tags.</p>
+    <video width="320" height="240" controls>
+      <source src="/videos/sample.mp4" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
+    <p>We've extended the default configuration to allow the <code>video</code> tag with its attributes.</p>
+  `,
+  useSanitizerDefaultAllowedTags: true,
+  useSanitizerDefaultAllowedAttributes: true,
+  allowedTags: ['video', 'source'],
+  allowedAttributes: {
+    video: ['width', 'height', 'controls', 'autoplay', 'muted', 'loop', 'poster'],
+    source: ['src', 'type'],
   },
 }
+WithExtendedAllowedTagsAndAttributes.storyName = 'With Extended Allowed Tags and Attributes'
 
-export const WithTailwindStyles = {
-  render: Template.bind({}),
-  name: 'With Tailwind styles',
-
-  args: {
-    content: '<div class="bg-color-1-300"><h1 class="text-5xl">Title</h1></div>',
+export const WithOverriddenAllowedTagsAndAttributes = Template.bind({})
+WithOverriddenAllowedTagsAndAttributes.args = {
+  content: `
+    <p>This example overrides the default allowed tags and attributes.</p>
+    <p>Only paragraph tags with class attributes are allowed in this example.</p>
+    <p class="text-red-500">This paragraph has a class and should be visible.</p>
+    <div>This div tag should be sanitized out.</div>
+    <iframe src="https://example.com">This iframe should be sanitized out.</iframe>
+  `,
+  useSanitizerDefaultAllowedTags: false,
+  useSanitizerDefaultAllowedAttributes: false,
+  allowedTags: ['p'],
+  allowedAttributes: {
+    p: ['class'],
   },
 }
-
-export const WithStyleTag = {
-  render: Template.bind({}),
-  name: 'With style tag',
-
-  args: {
-    content: '<div style="background-color: red;"><h1 style="font-size: 3rem;">Title</h1></div>',
-  },
-}
-
-export const WithAriaAttributes = {
-  render: Template.bind({}),
-  name: 'With aria attributes',
-
-  args: {
-    content:
-      '<a class="bg-color-1-300 disabled:opacity-50" href="#" disabled aria-label="I am a disabled link">Accessible link</a>',
-  },
-}
-
-export const YoutubeEmbedVideoIframe = {
-  render: Template.bind({}),
-  name: 'Youtube embed video iframe',
-
-  args: {
-    content:
-      '<p>Attributes of iframe : width, height, src, title, frameborder, allow, referrerpolicy, allowfullscreen</p><iframe width="560" height="315" src="https://www.youtube.com/embed/p-LFh5Y89eM?si=kTfC2QRi646JaaeK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
-  },
-}
-
-export const WebsiteWithScrolling = {
-  render: Template.bind({}),
-  name: 'Website with scrolling',
-
-  args: {
-    content:
-      '<iframe src="https://storybook.js.org/docs" title="storybook doc" height="600" width="600" marginwidth="50" scrolling="yes"></iframe>',
-  },
-}
-
-export const WithImageTag = {
-  render: Template.bind({}),
-  name: 'With image tag',
-
-  args: {
-    content: '<img src="/images/image.png" alt="image" />',
-  },
-}
+WithOverriddenAllowedTagsAndAttributes.storyName = 'With Overridden Allowed Tags and Attributes'


### PR DESCRIPTION
## Issue Link
https://okamca.atlassian.net/browse/STACK-256

## Implementation details
- [x] Default allowed tags should be overridable
- [x] Default allowed attributes should be overridable

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced configuration options for content sanitisation in the WYSIWYG block. Users can now customise which HTML elements and attributes are allowed, while secure default settings remain in place for added flexibility.
  - Added new stories to demonstrate various configurations of allowed tags and attributes in the WYSIWYG block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->