### PR TITLE
fix: issue with react hook form and react aria

### DIFF
--- a/libs/stack/stack-ui/.storybook/preview.js
+++ b/libs/stack/stack-ui/.storybook/preview.js
@@ -5,6 +5,17 @@ import React, { Suspense } from 'react'
 import { I18nProvider, OverlayProvider } from 'react-aria'
 import BaseThemeProvider from '../src/theme'
 import { IsClientContextProvider } from '../src/providers/Client'
+import { FormProvider, useForm } from 'react-hook-form'
+import { TranslationContextProvider } from '../src'
+
+const useTranslationFunc = () => {
+  return {
+    t: (key) => key,
+    i18n: {
+      language: 'en',
+    },
+  }
+}
 
 export const parameters = {
   layout: 'centered',
@@ -27,6 +38,9 @@ export const parameters = {
 export const decorators = [
   (Story, context) => {
     const locale = context?.globals?.locale || 'en'
+    const methods = useForm({
+      defaultValues: context?.globals?.defaultValues || {},
+    })
     return (
       <>
         <style>
@@ -38,13 +52,17 @@ export const decorators = [
         </style>
         <BaseThemeProvider>
           <I18nProvider locale={locale}>
+          <TranslationContextProvider useTranslationFunc={useTranslationFunc}>
             <IsClientContextProvider>
               <OverlayProvider>
-                <Suspense fallback={<div>Loading... </div>}>
-                  <Story />
-                </Suspense>
-              </OverlayProvider>
-            </IsClientContextProvider>
+                <FormProvider {...methods}>
+                  <Suspense fallback={<div>Loading... </div>}>
+                    <Story />
+                  </Suspense>
+                </FormProvider>
+                </OverlayProvider>
+              </IsClientContextProvider>
+            </TranslationContextProvider>
           </I18nProvider>
         </BaseThemeProvider>
       </>

--- a/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/interface.ts
@@ -1,6 +1,6 @@
 import type { InputHTMLAttributes } from 'react'
 import type { AriaTextFieldOptions } from 'react-aria'
-import type { RefCallBack } from 'react-hook-form'
+import type { ControllerRenderProps, RefCallBack } from 'react-hook-form'
 import type { TToken } from '../../../providers/Theme/interface'
 import type { TDefaultComponent, TReactHookForm } from '../../../types/components'
 
@@ -12,6 +12,8 @@ export interface TTextInputProps<T = TToken>
   name: string
   ariaLabel?: string
   errorMessage?: string
+  field?: ControllerRenderProps
+  isInvalid?: boolean
   fieldRef?: RefCallBack
   /**
    * @deprecated use isRequired instead

--- a/libs/stack/stack-ui/src/components/fields/TextInputField/text-input-field.stories.jsx
+++ b/libs/stack/stack-ui/src/components/fields/TextInputField/text-input-field.stories.jsx
@@ -1,4 +1,4 @@
-import TextInputField from './index'
+import { ReactHookFormInput as TextInputField } from './index'
 
 const Template = (args) => {
   const { backgroundColor, ...rest } = args


### PR DESCRIPTION
## Issue Link

## Implementation details
- [ ] fix React Aria and React Hook Form integration on InputText

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Input Text work as intended with React Hook Form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the preview environment with integrated translation support and robust form management, enhancing the interactive component experience.
  - Enhanced text input fields now offer additional states such as validation feedback, placeholder text, and read-only mode, resulting in improved accessibility and theming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->