### PR TITLE
STACK-272-side-panel-context-provider-button-props-should-be-typed-as-aria-button-props-button

### DIFF
--- a/libs/stack/stack-ui/src/components/Modal/index.tsx
+++ b/libs/stack/stack-ui/src/components/Modal/index.tsx
@@ -19,7 +19,7 @@ const Modal = <T extends TToken>(props: TModalProps<T>) => {
 
   return (
     <OverlayContainer>
-      <TransitionComponent themeName={`${themeName}.transition`} isVisible={state.isOpen}>
+      <TransitionComponent themeName={`${themeName}.transition`} tokens={tokens} isVisible={state.isOpen}>
         <ModalOverlay themeName={themeName} tokens={tokens} state={state} {...rest}>
           <ModalDialog themeName={themeName} tokens={tokens} {...rest}>
             {children}

--- a/libs/stack/stack-ui/src/components/SidePanel/index.tsx
+++ b/libs/stack/stack-ui/src/components/SidePanel/index.tsx
@@ -42,8 +42,10 @@ const SidePanel = <T extends TToken>(props: TSidePanelProps<T>) => {
           tokens={tokens}
           isVisible={overlayState.isOpen}
         >
-          <Box themeName={`${themeName}.container`}>
-            <Box themeName={`${themeName}.innerContainer`}>{children}</Box>
+          <Box themeName={`${themeName}.container`} tokens={tokens}>
+            <Box themeName={`${themeName}.innerContainer`} tokens={tokens}>
+              {children}
+            </Box>
           </Box>
         </TransitionAnimation>
       </Div100vh>

--- a/libs/stack/stack-ui/src/index.ts
+++ b/libs/stack/stack-ui/src/index.ts
@@ -78,6 +78,7 @@ export type { TSelectProps } from './components/fields/Select/Select.interface'
 export type { TBoxProps } from './components/Box/interface'
 export type { TDatePickerProps } from './components/fields/DatePicker/interface'
 export type { TDateProps } from './components/Date/interface'
+export type { TSidePanelButtons, TSidePanelButtonProps, TSidePanelContext } from './providers/SidePanel/interface'
 
 // utils
 export { default as generateUtmTags } from './components/ShareButton/utils/generateUtmTags'

--- a/libs/stack/stack-ui/src/providers/SidePanel/interface.ts
+++ b/libs/stack/stack-ui/src/providers/SidePanel/interface.ts
@@ -23,6 +23,15 @@ export type TSidePanelButtons = {
   openButtonRef: React.MutableRefObject<null>
 }
 
+/**
+ * @deprecated Use `TSidePanelButtons` instead
+ * @example
+ * ```tsx
+ * import type { TSidePanelButtons } from '@okam/stack-ui'
+ * ```
+ */
+export type TButtonProps = TSidePanelButtons
+
 export type TSidePanelContext = {
   defaultSelectedKey: string
   overlayState: OverlayTriggerState

--- a/libs/stack/stack-ui/src/providers/SidePanel/interface.ts
+++ b/libs/stack/stack-ui/src/providers/SidePanel/interface.ts
@@ -1,7 +1,8 @@
 import type { OverlayTriggerState } from '@react-stately/overlays'
 import type { DOMProps } from '@react-types/shared'
 import type React from 'react'
-import type { OverlayTriggerProps } from 'react-aria'
+import type { ButtonHTMLAttributes } from 'react'
+import type { AriaButtonProps, OverlayTriggerProps } from 'react-aria'
 
 export type TSidePanelProviderProps = Partial<OverlayTriggerProps> & {
   children: React.ReactNode
@@ -11,16 +12,20 @@ export type TSidePanelProviderProps = Partial<OverlayTriggerProps> & {
   onCloseCallback?: () => void
 }
 
-export type TButtonProps = {
-  closeButtonProps: React.ButtonHTMLAttributes<HTMLButtonElement>
+export type TSidePanelButtonProps = Omit<AriaButtonProps<'button'>, 'onPress'> & {
+  handlePress?: AriaButtonProps<'button'>['onPress']
+}
+
+export type TSidePanelButtons = {
+  closeButtonProps: TSidePanelButtonProps & ButtonHTMLAttributes<HTMLButtonElement>
   closeButtonRef: React.MutableRefObject<null>
-  openButtonProps: React.HTMLAttributes<HTMLDivElement>
+  openButtonProps: TSidePanelButtonProps & React.HTMLAttributes<HTMLDivElement>
   openButtonRef: React.MutableRefObject<null>
 }
 
 export type TSidePanelContext = {
   defaultSelectedKey: string
   overlayState: OverlayTriggerState
-  buttonProps: TButtonProps
+  buttonProps: TSidePanelButtons
   overlayProps: DOMProps
 }


### PR DESCRIPTION
## Issue
https://okamca.atlassian.net/browse/STACK-272

## Implementation details
- [x] Side panel context provider `buttonProps` should be typed correctly (to integrate `handlePress` and other react aria props)
- [x] Side panel should pass tokens to all of its sub components

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the SidePanel interface to offer refined options for custom button interactions and context usage.
  - Introduced a `tokens` prop to the SidePanel and Modal components, allowing for improved styling and behavior based on provided tokens.
- **Refactor**
  - Updated button property configurations to replace legacy settings with improved, streamlined alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->