### PR TITLE
STACK-76-Component-NextLink-wrapper

### DIFF
--- a/apps/demo/app/[locale]/Providers.tsx
+++ b/apps/demo/app/[locale]/Providers.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { I18nProvider } from 'react-aria'
+
+const Providers = (props: { children: React.ReactNode; locale: string }) => {
+  const { children, locale } = props
+  return <I18nProvider locale={locale}>{children}</I18nProvider>
+}
+
+export default Providers

--- a/apps/demo/app/[locale]/layout.tsx
+++ b/apps/demo/app/[locale]/layout.tsx
@@ -1,0 +1,5 @@
+import Providers from './Providers'
+
+export default function RootLayout({ children, params }: { children: React.ReactNode; params: { locale: string } }) {
+  return <Providers locale={params.locale}>{children}</Providers>
+}

--- a/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
@@ -1,4 +1,4 @@
-import type { TLinkOptions } from '@okam/next-component'
+import type { TLinkProps } from '@okam/next-component'
 import { Link } from '@okam/next-component'
 import { Box, Typography } from '@okam/stack-ui'
 
@@ -6,7 +6,7 @@ const ProductsLinks = (
   props: Parameters<typeof Page>[0] & {
     title: string
     description: string
-    scroll: TLinkOptions['scroll']
+    scroll: TLinkProps['scroll']
   },
 ) => {
   const { title, description, scroll, ...rest } = props

--- a/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
@@ -10,8 +10,8 @@ const ProductsLinks = (
   },
 ) => {
   const { title, description, scroll, ...rest } = props
-  const { id, locale } = rest.params
-  const route = `/${locale}/next-component/link/products`
+  const { id } = rest.params
+  const route = `/next-component/link/products`
   const nextId = Number.isNaN(parseInt(id, 10)) ? 1 : parseInt(id, 10) + 1
   const href = `${route}/${nextId}`
 

--- a/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/[id]/page.tsx
@@ -1,0 +1,45 @@
+import type { TLinkOptions } from '@okam/next-component'
+import { Link } from '@okam/next-component'
+import { Box, Typography } from '@okam/stack-ui'
+
+const ProductsLinks = (
+  props: Parameters<typeof Page>[0] & {
+    title: string
+    description: string
+    scroll: TLinkOptions['scroll']
+  },
+) => {
+  const { title, description, scroll, ...rest } = props
+  const { id, locale } = rest.params
+  const route = `/${locale}/next-component/link/products`
+  const nextId = Number.isNaN(parseInt(id, 10)) ? 1 : parseInt(id, 10) + 1
+  const href = `${route}/${nextId}`
+
+  return (
+    <Box customTheme="flex flex-col gap-4">
+      <Typography tokens={{ size: 'h2' }}>{title}</Typography>
+      <Typography tokens={{ size: 'p' }}>{description}</Typography>
+      <Link scroll={scroll} href={route}>
+        Home page
+      </Link>
+      <Link scroll={scroll} href={href}>
+        Next product
+      </Link>
+    </Box>
+  )
+}
+
+export default async function Page(props: { params: { id: string; locale: string } }) {
+  return (
+    <Box customTheme="p-8">
+      <ProductsLinks
+        {...props}
+        title="True"
+        description="Default next.js behavior. Try to restore scroll position if the page has already been navigated to."
+        scroll
+      />
+      <ProductsLinks {...props} title="False" description="Disable scrolling." scroll={false} />
+      <ProductsLinks {...props} title="Top" description="Scroll to top on click." scroll="top" />
+    </Box>
+  )
+}

--- a/apps/demo/app/[locale]/next-component/link/products/layout.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/layout.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@okam/stack-ui'
+
+export default async function Layout(props: { children: React.ReactNode; params: { id: string; locale: string } }) {
+  const { children } = props
+
+  return (
+    <Box>
+      <Box customTheme="h-48 bg-gray-300 justify-center items-center flex">
+        <Typography tokens={{ size: 'h1' }}>Top of the page</Typography>
+      </Box>
+      <Box customTheme="h-screen bg-gray-100 justify-center items-center flex">
+        <Typography tokens={{ size: 'h1' }}>Very long content</Typography>
+      </Box>
+      {children}
+      <Box customTheme="h-48 bg-black text-white justify-center items-center flex">
+        <Typography tokens={{ size: 'h3' }}>Products footer</Typography>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/demo/app/[locale]/next-component/link/products/page.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/page.tsx
@@ -1,16 +1,13 @@
 import { Link } from '@okam/next-component'
 import { Box, Typography } from '@okam/stack-ui'
 
-export default async function Page(props: { params: { locale: string } }) {
-  const { params } = props
-  const { locale } = params
-
+export default async function Page() {
   return (
     <Box>
       <Box customTheme="h-48 bg-gray-300 justify-center items-center flex">
         <Typography tokens={{ size: 'h1' }}>Products home page</Typography>
       </Box>
-      <Link href={`/${locale}/next-component/link/products/1`}>Products 1</Link>
+      <Link href="/next-component/link/products/1">Products 1</Link>
     </Box>
   )
 }

--- a/apps/demo/app/[locale]/next-component/link/products/page.tsx
+++ b/apps/demo/app/[locale]/next-component/link/products/page.tsx
@@ -1,0 +1,16 @@
+import { Link } from '@okam/next-component'
+import { Box, Typography } from '@okam/stack-ui'
+
+export default async function Page(props: { params: { locale: string } }) {
+  const { params } = props
+  const { locale } = params
+
+  return (
+    <Box>
+      <Box customTheme="h-48 bg-gray-300 justify-center items-center flex">
+        <Typography tokens={{ size: 'h1' }}>Products home page</Typography>
+      </Box>
+      <Link href={`/${locale}/next-component/link/products/1`}>Products 1</Link>
+    </Box>
+  )
+}

--- a/libs/stack/next-component/.storybook/preview.tsx
+++ b/libs/stack/next-component/.storybook/preview.tsx
@@ -1,0 +1,15 @@
+import '../src/tailwind.css'
+import type { Preview } from '@storybook/react'
+import BaseThemeProvider from '../src/theme'
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <BaseThemeProvider>
+        <Story />
+      </BaseThemeProvider>
+    ),
+  ],
+}
+
+export default preview

--- a/libs/stack/next-component/package.json
+++ b/libs/stack/next-component/package.json
@@ -11,6 +11,7 @@
     "@okam/stack-ui": "1.32.6",
     "next": "^14.1.1",
     "react-use": "17.5.1",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "tailwind-variants": "^0.3.0"
   }
 }

--- a/libs/stack/next-component/package.json
+++ b/libs/stack/next-component/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@okam/stack-ui": "1.32.6",
-    "next": "^14.1.1"
+    "next": "^14.1.1",
+    "react-use": "17.5.1",
+    "react": "18.3.1"
   }
 }

--- a/libs/stack/next-component/postcss.config.js
+++ b/libs/stack/next-component/postcss.config.js
@@ -1,0 +1,15 @@
+const { join } = require('path')
+
+// Note: If you use library-specific PostCSS/Tailwind configuration then you should remove the `postcssConfig` build
+// option from your application's configuration (i.e. project.json).
+//
+// See: https://nx.dev/guides/using-tailwind-css-in-react#step-4:-applying-configuration-to-libraries
+
+module.exports = {
+  plugins: {
+    tailwindcss: {
+      config: join(__dirname, 'tailwind.config.js'),
+    },
+    autoprefixer: {},
+  },
+}

--- a/libs/stack/next-component/src/components/Link/index.tsx
+++ b/libs/stack/next-component/src/components/Link/index.tsx
@@ -2,19 +2,45 @@
 
 import { Anchor } from '@okam/stack-ui'
 import NextLink from 'next/link'
+import type { Ref } from 'react'
+import { forwardRef } from 'react'
 import { useLink } from '../../hooks/useLink'
 import type { TLinkProps } from './interface'
 
-const Link = (props: TLinkProps) => {
-  const { themeName = 'button', as = NextLink, href, children, scroll, ...rest } = props
+const Link = forwardRef((props: TLinkProps, ref: Ref<HTMLButtonElement & HTMLAnchorElement>) => {
+  const {
+    themeName = 'link',
+    tokens,
+    customTheme,
+    as = NextLink,
+    children,
+    scroll,
+    onPathnameChange,
+    onSearchParamsChange,
+    onHashChange,
+    behavior,
+    urlDecorator: urlDecoratorProp,
+    href: hrefProp,
+    ...rest
+  } = props
 
   const linkProps = useLink(props)
 
   return (
-    <Anchor as={as} themeName={themeName} nextLinkProps={{ ...rest, ...linkProps }}>
+    <Anchor
+      ref={ref}
+      {...rest}
+      nextLinkProps={linkProps}
+      as={as}
+      themeName={themeName}
+      tokens={tokens}
+      customTheme={customTheme}
+    >
       {children}
     </Anchor>
   )
-}
+})
+
+Link.displayName = 'Link'
 
 export default Link

--- a/libs/stack/next-component/src/components/Link/index.tsx
+++ b/libs/stack/next-component/src/components/Link/index.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Anchor } from '@okam/stack-ui'
+import NextLink from 'next/link'
+import { useLink } from '../../hooks/useLink'
+import type { TLinkProps } from './interface'
+
+const Link = (props: TLinkProps) => {
+  const { themeName = 'button', as = NextLink, href, children, scroll, ...rest } = props
+
+  const linkProps = useLink(props)
+
+  return (
+    <Anchor as={as} themeName={themeName} nextLinkProps={{ ...rest, ...linkProps }}>
+      {children}
+    </Anchor>
+  )
+}
+
+export default Link

--- a/libs/stack/next-component/src/components/Link/interface.ts
+++ b/libs/stack/next-component/src/components/Link/interface.ts
@@ -1,4 +1,4 @@
 import type { TDefaultComponent, TToken } from '@okam/stack-ui'
-import type { TLinkOptions } from '../../hooks/useLink/interface'
+import type { TLink } from '../../hooks/useLink/interface'
 
-export interface TLinkProps<T = TToken> extends Omit<TDefaultComponent<T>, keyof TLinkOptions>, TLinkOptions {}
+export interface TLinkProps<T = TToken> extends Omit<TDefaultComponent<T>, keyof TLink>, TLink {}

--- a/libs/stack/next-component/src/components/Link/interface.ts
+++ b/libs/stack/next-component/src/components/Link/interface.ts
@@ -1,0 +1,4 @@
+import type { TDefaultComponent, TToken } from '@okam/stack-ui'
+import type { TLinkOptions } from '../../hooks/useLink/interface'
+
+export interface TLinkProps<T = TToken> extends Omit<TDefaultComponent<T>, keyof TLinkOptions>, TLinkOptions {}

--- a/libs/stack/next-component/src/components/Link/link.mdx
+++ b/libs/stack/next-component/src/components/Link/link.mdx
@@ -1,0 +1,42 @@
+import * as LinkStories from './link.stories'
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/blocks'
+
+<Meta of={LinkStories} />
+
+# Link
+
+The next component `Link` component is a wrapper for next/link that accepts themeing via `themeName`, `tokens` and `customTheme` props.
+
+It also add a few more features to the next/link component
+
+## Additional features
+
+- Option to scroll to the top of the page when the link is clicked
+- Automatic prepending of the locale to the href using either the `locale` prop or the next/navigation `useParams` hook (with the `locale` route parameter).
+- Callback functions for any changes to the href (pathname, searchParams, hash)
+
+## Props
+
+<Controls />
+
+## Example usage
+
+```tsx
+// Route: /[locale]/[category]/[productId]
+// Current pathname: /en/electronics/123
+
+<Link href="/electronics/456">Go to product 456</Link>
+// Resulting href: /en/electronics/456
+// The locale is deduced from the `locale` route parameter
+
+// Route: /[locale]/[category]/[productId]
+// Current pathname: /en/electronics/123
+
+<Link href="/electronics/456" locale="fr">Go to product 456</Link>
+// Resulting href: /fr/electronics/456
+// Passing the `locale` prop explicitly overrides the `locale` route parameter
+```
+
+## Showcase
+
+<Canvas of={LinkStories.ScrollDefault} />

--- a/libs/stack/next-component/src/components/Link/link.stories.tsx
+++ b/libs/stack/next-component/src/components/Link/link.stories.tsx
@@ -1,0 +1,164 @@
+import { Box } from '@okam/stack-ui'
+import type { Meta, StoryObj } from '@storybook/react'
+import Link from './index'
+
+const meta: Meta<typeof Link> = {
+  title: 'Link',
+  component: Link,
+  parameters: {
+    docs: {
+      decorators: false,
+    },
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/[locale]/products/[id]',
+        asPath: '/fr/products/1',
+        query: {
+          id: '1',
+          locale: 'fr',
+        },
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <Box customTheme="h-screen bg-gray-100 flex items-center justify-center mb-8">This is long content</Box>
+        <Story />
+      </>
+    ),
+  ],
+  args: {
+    locale: 'en',
+    href: '/products/2',
+    children: 'Product 2',
+    scroll: true,
+    behavior: 'instant',
+    onClick: (e) => console.log('Click', e),
+    onMouseEnter: (e) => console.log('Mouse enter', e),
+    onTouchStart: (e) => console.log('Touch start', e),
+    onPathnameChange: (pathname) => console.log('Pathname change', pathname),
+    onSearchParamsChange: (searchParams) => console.log('Search params change', searchParams),
+    onHashChange: (hash) => console.log('Hash change', hash),
+  },
+  argTypes: {
+    scroll: {
+      description: 'Defines the scrolling action on link click.',
+      control: { type: 'radio' },
+      options: [true, false, 'top'],
+      table: {
+        type: {
+          summary: 'boolean | "top"',
+          detail: `
+- \`true\` attempts to preserve previously set scrolling position.
+- \`false\` will not scroll.
+- \`"top"\` will scroll to the top of the page (behavior depending on \`behavior\` prop)
+          `,
+        },
+      },
+    },
+    children: {
+      control: false,
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    onPathnameChange: {
+      control: false,
+      description: 'Callback function that is called when the pathname changes. Relies on `usePathname` hook.',
+    },
+    onSearchParamsChange: {
+      control: false,
+      description: 'Callback function that is called when the search params change. Relies on `useSearchParams` hook.',
+    },
+    onHashChange: {
+      control: false,
+      description: 'Callback function that is called when the hash changes. Relies on `useHash` hook.',
+    },
+    href: {
+      table: {
+        category: 'next/link',
+        type: { summary: 'string | URL' },
+      },
+    },
+    prefetch: {
+      table: {
+        category: 'next/link',
+      },
+    },
+    replace: {
+      table: {
+        category: 'next/link',
+      },
+    },
+    shallow: {
+      table: {
+        category: 'next/link',
+      },
+    },
+    passHref: {
+      table: {
+        category: 'next/link',
+      },
+    },
+    legacyBehavior: {
+      table: {
+        category: 'next/link',
+      },
+    },
+    locale: {
+      description:
+        'The active locale is automatically prepended. locale allows for providing a different locale. When `false` href has to include the locale as the default behavior is disabled. By default, the locale will try to be set via the `locale` prop, then the `useParams` hook. with the `locale` dynamic route segment.',
+      table: {
+        category: 'next/link',
+      },
+    },
+    urlDecorator: {
+      control: false,
+      name: 'as (urlDecorator)',
+      description:
+        'Originally named `as` in next/link, prop was renamed to avoid conflicts with the `as` prop of `TDefaultComponent`.',
+      table: {
+        category: 'next/link',
+        type: { summary: 'string | URL' },
+      },
+    },
+    onClick: {
+      control: false,
+      table: {
+        category: 'next/link',
+      },
+    },
+    onMouseEnter: {
+      control: false,
+      table: {
+        category: 'next/link',
+      },
+    },
+    onTouchStart: {
+      control: false,
+      table: {
+        category: 'next/link',
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Link>
+
+export const ScrollDefault: Story = {}
+
+export const ScrollFalse: Story = {
+  args: {
+    scroll: false,
+  },
+}
+
+export const ScrollTop: Story = {
+  args: {
+    scroll: 'top',
+  },
+}

--- a/libs/stack/next-component/src/hooks/useHash/index.ts
+++ b/libs/stack/next-component/src/hooks/useHash/index.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+import { useEvent } from 'react-use'
+
+function getHash() {
+  if (typeof window === 'undefined') return ''
+  return window.location.hash
+}
+
+/**
+ * A hook that lets you read the current URL's hash.
+ *
+ * @returns The current `window.location.hash`, including the leading `#` character.
+ */
+export function useHash() {
+  const defaultHash = getHash()
+  const [hash, setHash] = useState(defaultHash)
+
+  const handleHashChangeEvent = ({ newURL }: HashChangeEvent) => {
+    if (!URL.canParse(newURL)) return
+
+    const { hash: newHash } = new URL(newURL)
+    if (!newHash || newHash === hash) return
+
+    setHash(newHash)
+  }
+
+  useEvent('hashchange', handleHashChangeEvent)
+
+  return hash
+}

--- a/libs/stack/next-component/src/hooks/useLink/index.ts
+++ b/libs/stack/next-component/src/hooks/useLink/index.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import type { LinkProps as NextLinkProps } from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect } from 'react'
+import { useHash } from '../useHash'
+import type { TLinkOptions } from './interface'
+
+function scrollToTop(behavior: ScrollBehavior) {
+  window?.scrollTo?.({ top: 0, behavior })
+}
+
+export function useLink(props: TLinkOptions): NextLinkProps {
+  const {
+    scroll = true,
+    onMouseEnter,
+    onTouchStart,
+    onClick,
+    onPathnameChange,
+    onHashChange,
+    onSearchParamsChange,
+    href,
+    urlDecorator,
+    replace,
+    locale,
+    prefetch,
+    shallow,
+    passHref,
+    legacyBehavior,
+    behavior = 'instant',
+  } = props
+
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const hash = useHash()
+
+  const isNextScroll = typeof scroll === 'boolean'
+  const nextScroll = isNextScroll ? scroll : false
+
+  const handleScroll = useCallback(() => {
+    if (isNextScroll) return
+
+    scrollToTop(behavior)
+  }, [behavior, isNextScroll])
+
+  const handleClick: typeof onClick = (event) => {
+    onClick?.(event)
+    handleScroll()
+  }
+
+  const handleTouchStart: typeof onTouchStart = (event) => {
+    onTouchStart?.(event)
+    handleScroll()
+  }
+
+  useEffect(() => {
+    onPathnameChange?.(pathname)
+  }, [onPathnameChange, pathname])
+
+  useEffect(() => {
+    onSearchParamsChange?.(searchParams)
+  }, [onSearchParamsChange, searchParams])
+
+  useEffect(() => {
+    onHashChange?.(hash)
+  }, [onHashChange, hash])
+
+  return {
+    href,
+    as: urlDecorator,
+    replace,
+    locale,
+    prefetch,
+    shallow,
+    onClick: handleClick,
+    onTouchStart: handleTouchStart,
+    onMouseEnter,
+    scroll: nextScroll,
+    passHref,
+    legacyBehavior,
+  }
+}

--- a/libs/stack/next-component/src/hooks/useLink/interface.ts
+++ b/libs/stack/next-component/src/hooks/useLink/interface.ts
@@ -1,0 +1,28 @@
+import type { LinkProps as NextLinkProps } from 'next/link'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
+
+export type TScrollProp =
+  | NextLinkProps['scroll']
+  /**
+   * Scroll to the top of the page when the link is clicked.
+   */
+  | 'top'
+
+export interface TLink extends Omit<NextLinkProps, 'scroll' | 'as'> {
+  /**
+   * @default true
+   */
+  scroll?: TScrollProp | undefined
+  urlDecorator?: NextLinkProps['as']
+  /**
+   * Used for the automatic scroll when `scroll = 'top'`
+   * @default 'instant'
+   */
+  behavior?: ScrollBehavior
+}
+
+export interface TLinkOptions extends TLink {
+  onPathnameChange?: (pathname: string) => void
+  onSearchParamsChange?: (searchParams: ReadonlyURLSearchParams) => void
+  onHashChange?: (hash: string) => void
+}

--- a/libs/stack/next-component/src/hooks/useLink/interface.ts
+++ b/libs/stack/next-component/src/hooks/useLink/interface.ts
@@ -1,28 +1,25 @@
 import type { LinkProps as NextLinkProps } from 'next/link'
 import type { ReadonlyURLSearchParams } from 'next/navigation'
 
-export type TScrollProp =
-  | NextLinkProps['scroll']
-  /**
-   * Scroll to the top of the page when the link is clicked.
-   */
-  | 'top'
-
 export interface TLink extends Omit<NextLinkProps, 'scroll' | 'as'> {
   /**
    * @default true
+   * - `true`: Scrolls to the top of the clicked anchor (default Next.js behavior)
+   * - `false`: Prevents any automatic scrolling
+   * - `'top'`: Always scrolls to the top of the page, regardless of anchor
    */
-  scroll?: TScrollProp | undefined
+  scroll?: 'top' | boolean
   urlDecorator?: NextLinkProps['as']
   /**
    * Used for the automatic scroll when `scroll = 'top'`
-   * @default 'instant'
+   * @default instant
    */
   behavior?: ScrollBehavior
-}
-
-export interface TLinkOptions extends TLink {
   onPathnameChange?: (pathname: string) => void
   onSearchParamsChange?: (searchParams: ReadonlyURLSearchParams) => void
   onHashChange?: (hash: string) => void
+}
+
+export interface TUseLinkReturn extends Omit<NextLinkProps, 'href'> {
+  href: string
 }

--- a/libs/stack/next-component/src/index.ts
+++ b/libs/stack/next-component/src/index.ts
@@ -6,4 +6,4 @@ export { useHash } from './hooks/useHash'
 
 export type { default as TImgProps } from './components/Img/interface'
 export type { TLinkProps } from './components/Link/interface'
-export type { TLinkOptions, TLink } from './hooks/useLink/interface'
+export type { TLink } from './hooks/useLink/interface'

--- a/libs/stack/next-component/src/index.ts
+++ b/libs/stack/next-component/src/index.ts
@@ -1,3 +1,9 @@
 export { default as Img } from './components/Img'
+export { default as Link } from './components/Link'
+
+export { useLink } from './hooks/useLink'
+export { useHash } from './hooks/useHash'
 
 export type { default as TImgProps } from './components/Img/interface'
+export type { TLinkProps } from './components/Link/interface'
+export type { TLinkOptions, TLink } from './hooks/useLink/interface'

--- a/libs/stack/next-component/src/tailwind.css
+++ b/libs/stack/next-component/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/libs/stack/next-component/src/theme/Link/index.ts
+++ b/libs/stack/next-component/src/theme/Link/index.ts
@@ -1,0 +1,81 @@
+import { tv } from 'tailwind-variants'
+
+const linkTheme = tv({
+  base: `
+    flex
+    items-center
+    justify-center
+    gap-4
+    transition
+    duration-300
+    ease-in-out
+    disabled:pointer-events-none
+    disabled:opacity-30
+    focus-ring-black
+  `,
+  defaultVariants: {
+    buttonStyle: 'ghost',
+    type: 'button',
+    size: 'default',
+    shape: 'rounded',
+  },
+  variants: {
+    type: {
+      button: '',
+      menu: 'text-2xl',
+    },
+    buttonStyle: {
+      default: `
+        px-4
+        py-2
+        text-white
+        !bg-color-1-500
+        hover:!bg-color-1-400
+        active:!bg-color-1-400
+      `,
+      outline: `
+        px-4
+        py-2
+        bg-transparent
+        !border-color-1-500
+        text-color-1-500
+        hover:bg-color-1-500
+        hover:text-white
+        active:bg-color-1-500
+        active:text-white
+      `,
+      hollow: `
+        px-2
+        bg-transparent
+        text-color-1-500
+        hover:border-b-color-1-500
+        active:border-b-color-1-500
+        focus:border-b-color-1-500
+      `,
+      ghost: `
+        bg-transparent
+        text-color-1-500
+        hover:text-color-1-400
+        active:text-color-1-400
+      `,
+    },
+    intent: {
+      error: `
+        !bg-error
+        text-white
+        pointer-events-none
+        !border-error
+      `,
+    },
+    size: {
+      default: `min-w-12 min-h-6`,
+      large: `min-w-36 min-h-18`,
+    },
+    shape: {
+      rounded: `rounded-md`,
+      circular: `rounded-full`,
+    },
+  },
+})
+
+export default linkTheme

--- a/libs/stack/next-component/src/theme/index.ts
+++ b/libs/stack/next-component/src/theme/index.ts
@@ -1,0 +1,9 @@
+import { createThemeProvider, makeTheme } from '@okam/stack-ui'
+import { memo } from 'react'
+import linkTheme from './Link'
+
+const baseTheme = makeTheme({
+  link: linkTheme,
+})
+
+export default memo(createThemeProvider(baseTheme))

--- a/libs/stack/next-component/tailwind.config.js
+++ b/libs/stack/next-component/tailwind.config.js
@@ -1,0 +1,14 @@
+const { createGlobPatternsForDependencies } = require('@nx/react/tailwind')
+const { join } = require('path')
+
+module.exports = {
+  content: [
+    join(__dirname, '{src,pages,components,app,theme}/**/*.{js,ts,jsx,tsx,mdx,html}'),
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  presets: [require('../../../tailwind.preset')],
+}

--- a/libs/stack/next-component/tsconfig.storybook.json
+++ b/libs/stack/next-component/tsconfig.storybook.json
@@ -26,6 +26,7 @@
     "src/**/*.stories.tsx",
     "src/**/*.stories.mdx",
     ".storybook/*.js",
-    ".storybook/*.ts"
+    ".storybook/*.ts",
+    ".storybook/*.tsx"
   ]
 }

--- a/libs/stack/stack-ui/src/components/Button/interface.ts
+++ b/libs/stack/stack-ui/src/components/Button/interface.ts
@@ -19,5 +19,8 @@ export interface TButtonProps<T = TToken> extends TDefaultComponent<T> {
 }
 
 export interface TAnchorProps<T = TToken> extends TButtonProps<T> {
+  /**
+   * @deprecated To render a themeable `next/link` component, use the `Link` component from `@okam/next-component`.
+   */
   nextLinkProps?: NextLinkProps
 }

--- a/libs/stack/stack-ui/src/theme/index.tsx
+++ b/libs/stack/stack-ui/src/theme/index.tsx
@@ -83,6 +83,7 @@ const BaseTheme = makeTheme({
   },
   typography: (props) => typography(props),
   button: (props) => button(props),
+  link: button,
   sidePanel: {
     wrapper: (props) => sidePanelWrapper(props),
     container: (props) => sidePanelContainer(props),

--- a/libs/stack/stack-ui/src/types/next-link.ts
+++ b/libs/stack/stack-ui/src/types/next-link.ts
@@ -6,7 +6,7 @@ export type NextLinkProps = {
   scroll?: boolean
   shallow?: boolean
   passHref?: boolean
-  prefetch?: boolean
+  prefetch?: boolean | null
   locale?: string | false
   legacyBehavior?: boolean
   onMouseEnter?: React.MouseEventHandler<HTMLAnchorElement>

--- a/libs/stack/stack-ui/src/types/next-link.ts
+++ b/libs/stack/stack-ui/src/types/next-link.ts
@@ -12,4 +12,5 @@ export type NextLinkProps = {
   onMouseEnter?: React.MouseEventHandler<HTMLAnchorElement>
   onTouchStart?: React.TouchEventHandler<HTMLAnchorElement>
   onClick?: React.MouseEventHandler<HTMLAnchorElement>
+  as?: string | UrlObject
 }


### PR DESCRIPTION
## Issue
https://okamca.atlassian.net/browse/STACK-76

## Implementation details
### Features
New useLink hook/Link component should support:
- [x] Scrolling to top on click
- [x] Extend the next/link interface for compatibility
- [x] Automatic pre-pending of the locale (are we planning on having a CMS-agnostic locale provider of some kind? currently using next/navigation `useParams`/direct prop assignement)
- [x] Stack-ui themeing
- [x] All props from `TDefaultComponent` 

### Docs
- [x] Should have demos in next app
- [x] Should have storybook documentation
- [x] Should have stack-ui Anchor component's `nextLinkProps` as deprecated

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- next-component storybook -> Link story
- demo
- /en/next-component/link/products
- Test interactivity in next app environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced new components for localized content and product navigation, featuring interactive links with advanced scrolling behaviours and responsive layouts.
  - Added hooks for managing link behaviour and hash navigation, enhancing user interaction with URLs.
  - Implemented a new theming system for links, allowing for customizable styles and variants.

- **Documentation**
  - Expanded Storybook guides and component demos provide clear instructions for using the new interactive features.

- **Chores**
  - Upgraded key dependencies and refined configuration settings to ensure improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->