### PR TITLE
STACK-275-Component-Tag-TagGroup

### DIFF
--- a/libs/stack/stack-ui/src/components/Button/index.tsx
+++ b/libs/stack/stack-ui/src/components/Button/index.tsx
@@ -65,7 +65,8 @@ const Button = React.forwardRef((props: TButtonProps, forwardRef: React.Ref<HTML
   )
 
   const theme = useThemeContext(themeName, tokens, customTheme)
-  const { onPress, onFocusChange, ...allProps } = rest as Record<string, unknown>
+  // excludeFromTabOrder being spread on an element creates unknown attributes error
+  const { onPress, onFocusChange, excludeFromTabOrder, ...allProps } = rest as Record<string, unknown>
 
   return (
     <FocusRing within focusRingClass="has-focus-ring">

--- a/libs/stack/stack-ui/src/components/TagGroup/components/Tag.tsx
+++ b/libs/stack/stack-ui/src/components/TagGroup/components/Tag.tsx
@@ -1,0 +1,65 @@
+import { useRef } from 'react'
+import { FocusRing, useTag } from 'react-aria'
+import type { TToken } from '../../../providers/Theme/interface'
+import Box, { BoxWithForwardRef } from '../../Box'
+import Button from '../../Button'
+import type { TButtonProps } from '../../Button/interface'
+import type { TTagProps } from '../interface'
+
+const Tag = <Item extends object, T = TToken>(props: TTagProps<Item, T>) => {
+  const { themeName, tokens, customTheme, as, item, state, ...rest } = props
+  const { removeButtonProps: removeButtonPropsItem, href } = item.props ?? {}
+  const ref = useRef(null)
+  const {
+    rowProps,
+    gridCellProps,
+    removeButtonProps: removeButtonPropsAria,
+    allowsRemoving,
+    isDisabled,
+    isFocused,
+    isPressed,
+    isSelected,
+  } = useTag(props, state, ref)
+
+  const tagTokens = {
+    ...tokens,
+    isDisabled,
+    isFocused,
+    isPressed,
+    isSelected,
+    isLink: !!href,
+  }
+
+  const removeButtonProps: TButtonProps = {
+    ...removeButtonPropsItem,
+    ...removeButtonPropsAria,
+    handlePress: (e) => {
+      removeButtonPropsItem?.handlePress?.(e)
+      removeButtonPropsAria?.onPress?.(e)
+    },
+  }
+
+  return (
+    <FocusRing focusRingClass="has-focus-ring within">
+      <BoxWithForwardRef
+        {...rest}
+        {...rowProps}
+        ref={ref}
+        themeName={`${themeName}.wrapper`}
+        tokens={tagTokens}
+        customTheme={customTheme}
+      >
+        <Box themeName={`${themeName}.container`} tokens={tagTokens} {...gridCellProps}>
+          <Box themeName={`${themeName}.item`} tokens={tagTokens}>
+            {item.rendered}
+          </Box>
+          {allowsRemoving && removeButtonPropsItem && (
+            <Button themeName={`${themeName}.removeButton`} tokens={tagTokens} {...removeButtonProps} />
+          )}
+        </Box>
+      </BoxWithForwardRef>
+    </FocusRing>
+  )
+}
+
+export default Tag

--- a/libs/stack/stack-ui/src/components/TagGroup/components/TagItem.tsx
+++ b/libs/stack/stack-ui/src/components/TagGroup/components/TagItem.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { PartialNode } from '@react-stately/collections'
+import type { ItemProps } from '@react-types/shared'
+import type { JSX, ReactElement } from 'react'
+import React from 'react'
+import { log } from '../../../logger'
+import type { TTagElement, TTagItemProps } from '../interface'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function TagItem<T>(props: ItemProps<T>): ReactElement | null {
+  return null
+}
+
+function hasChildItems<T>(props: ItemProps<T>) {
+  if (props.hasChildItems != null) {
+    return props.hasChildItems
+  }
+
+  if (props.childItems) {
+    return true
+  }
+
+  if (props.title && React.Children.count(props.children) > 0) {
+    return true
+  }
+
+  return false
+}
+
+TagItem.getCollectionNode = function* getCollectionNode<T extends object>(
+  props: TTagItemProps<T>,
+  context: any,
+): Generator<PartialNode<T>> {
+  const { childItems, title, children } = props
+
+  const rendered = props.title || props.children
+  const textValue = props.textValue || (typeof rendered === 'string' ? rendered : '') || props['aria-label'] || ''
+
+  if (!textValue && !context?.suppressTextValueWarning && process.env.NODE_ENV !== 'production') {
+    log(
+      '<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.',
+      'warn',
+    )
+  }
+
+  yield {
+    type: 'item',
+    props,
+    rendered,
+    textValue,
+    'aria-label': props['aria-label'],
+    hasChildNodes: hasChildItems(props),
+    *childNodes() {
+      if (childItems) {
+        yield* Array.from(childItems).map((child) => ({
+          type: 'item',
+          value: child,
+        }))
+      } else if (title) {
+        const items: PartialNode<T>[] = []
+        React.Children.forEach(children, (child) => {
+          items.push({
+            type: 'item',
+            element: child as TTagElement<T>,
+          })
+        })
+
+        yield* items
+      }
+    },
+  }
+}
+
+// We don't want getCollectionNode to show up in the type definition
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/naming-convention
+const _TagItem = TagItem as <T extends object>(props: TTagItemProps<T>) => JSX.Element
+export { _TagItem as TagItem }

--- a/libs/stack/stack-ui/src/components/TagGroup/index.tsx
+++ b/libs/stack/stack-ui/src/components/TagGroup/index.tsx
@@ -1,0 +1,56 @@
+import { useRef } from 'react'
+import { useTagGroup } from 'react-aria'
+import { useListState } from 'react-stately'
+import type { TToken } from '../../providers/Theme/interface'
+import Box, { BoxWithForwardRef } from '../Box'
+import Typography from '../Typography'
+import Tag from './components/Tag'
+import type { TTagGroupProps } from './interface'
+
+const TagGroup = <Item extends object, T extends TToken = TToken>(props: TTagGroupProps<Item, T>) => {
+  const {
+    themeName = 'tagGroup',
+    tokens,
+    customTheme,
+    as,
+    label,
+    description,
+    errorMessage,
+    removeButtonProps = { children: '❌' },
+  } = props
+  const ref = useRef(null)
+  const state = useListState(props)
+  const { gridProps, labelProps, descriptionProps, errorMessageProps } = useTagGroup(props, state, ref)
+  return (
+    <Box as={as} themeName={`${themeName}.wrapper`} tokens={tokens} customTheme={customTheme}>
+      {label && (
+        <Typography themeName={`${themeName}.label`} tokens={tokens} {...labelProps}>
+          {label}
+        </Typography>
+      )}
+      <BoxWithForwardRef themeName={`${themeName}.tags`} tokens={tokens} ref={ref} {...gridProps}>
+        {[...state.collection].map((item) => (
+          <Tag
+            themeName={`${themeName}.tag`}
+            key={item.key}
+            tokens={tokens}
+            item={{ ...item, props: { removeButtonProps, ...item.props } }}
+            state={state}
+          />
+        ))}
+      </BoxWithForwardRef>
+      {description && (
+        <Typography themeName={`${themeName}.description`} tokens={tokens} {...descriptionProps}>
+          {description}
+        </Typography>
+      )}
+      {errorMessage && (
+        <Typography themeName={`${themeName}.errorMessage`} tokens={tokens} {...errorMessageProps}>
+          {errorMessage}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default TagGroup

--- a/libs/stack/stack-ui/src/components/TagGroup/interface.ts
+++ b/libs/stack/stack-ui/src/components/TagGroup/interface.ts
@@ -1,0 +1,40 @@
+import type { CollectionElement, ItemProps, Node } from '@react-types/shared'
+import type { ReactElement } from 'react'
+import type { AriaTagGroupProps, AriaTagProps } from 'react-aria'
+import type { ListState } from 'react-stately'
+import type { TToken } from '../../providers/Theme/interface'
+import type { TDefaultComponent } from '../../types/components'
+import type { TButtonProps } from '../Button/interface'
+
+type TTagCollectionElement<I extends object> = CollectionElement<I> & { removeButtonProps?: TButtonProps }
+
+export type TTagItem<I extends object> = I & {
+  removeButtonProps?: TButtonProps
+  href?: string
+}
+
+type TTagNode<I extends object> = Omit<Node<I>, 'props'> & { props?: TTagItem<I> & ItemProps<I> }
+
+export interface TTagGroupProps<I extends object, T = TToken>
+  extends Omit<TDefaultComponent<T>, 'children'>,
+    Omit<AriaTagGroupProps<TTagItem<I>>, 'children'> {
+  children: TTagCollectionElement<I> | TTagCollectionElement<I>[] | ((item: TTagItem<I>) => TTagCollectionElement<I>)
+  /**
+   * Acts as a default for the remove button of all tags. Individual tags `props.item.props.removeButtonProps` take precedence.
+   * @default {children: '❌'}
+   */
+  removeButtonProps?: TButtonProps
+}
+
+export interface TTagProps<I extends object, T = TToken>
+  extends Omit<TDefaultComponent<T>, 'children'>,
+    Omit<AriaTagProps<TTagItem<I>>, 'item'> {
+  state: ListState<TTagItem<I>>
+  item: TTagNode<I>
+}
+
+export type TTagItemProps<I extends object, T = TToken> = Omit<TDefaultComponent<T>, 'children'> &
+  ItemProps<I> &
+  TTagItem<I>
+
+export type TTagElement<I extends object> = ReactElement<TTagItemProps<I>>

--- a/libs/stack/stack-ui/src/components/TagGroup/tag-group.mdx
+++ b/libs/stack/stack-ui/src/components/TagGroup/tag-group.mdx
@@ -39,9 +39,28 @@ The following tokens are available on the `Tag` component:
 
 <Canvas of={TagGroupStories.ErrorMessage} />
 
-### Maximal Props
+### Maximal Props (Controlled)
 
-Maximal interactions (default selected, removable, disabled)
+Maximal interactions (default selected, removable, disabled).
+
+For controlled usage, you can use the `useListData` hook to manage the state of the tag group, although it is also possible with `useState` typed to `Set<Key>`. See the [useListData](https://react-spectrum.adobe.com/react-stately/useListData.html) documentation for more information.
+
+```tsx
+const items = [{ key: 'blue', children: 'Blue' }, { key: 'red', children: 'Red' }, { key: 'green', children: 'Green' }]
+const list = useListData({ initialItems: items, initialSelectedKeys: ['blue'] })
+
+return (
+  <TagGroup
+    items={list.items}
+    selectedKeys={list.selectedKeys}
+    onSelectionChange={list.setSelectedKeys}
+    onRemove={list.remove}
+  >
+    {/* Spreading the key prop gives a warning */}
+    {({ key, ...item }) => <TagItem {...item} key={key} />}
+  </TagGroup>
+)
+```
 
 <Canvas of={TagGroupStories.MaximalProps} />
 

--- a/libs/stack/stack-ui/src/components/TagGroup/tag-group.mdx
+++ b/libs/stack/stack-ui/src/components/TagGroup/tag-group.mdx
@@ -1,0 +1,58 @@
+import * as TagGroupStories from './tag-group.stories'
+import { Meta, ArgTypes, Canvas } from '@storybook/blocks'
+
+<Meta of={TagGroupStories} />
+
+# TagGroup
+
+Tag group component. Allows to select multiple items from a list. Often used for filtering lists of data.
+
+## Props
+
+<ArgTypes of={TagGroupStories} />
+
+### Tokens
+
+The following tokens are available on the `Tag` component:
+
+- isLink (`boolean`) - Whether the tag is a link.
+- isDisabled (`boolean`) - Whether the tag is disabled.
+- isFocused (`boolean`) - Whether the tag is focused.
+- isPressed (`boolean`) - Whether the tag is pressed.
+- isSelected (`boolean`) - Whether the tag is selected.
+
+## Showcase
+
+### Default
+
+<Canvas of={TagGroupStories.Default} />
+
+### Removable
+
+<Canvas of={TagGroupStories.Removable} />
+
+### Selectable
+
+<Canvas of={TagGroupStories.Selectable} />
+
+### Error
+
+<Canvas of={TagGroupStories.ErrorMessage} />
+
+### Maximal Props
+
+Maximal interactions (default selected, removable, disabled)
+
+<Canvas of={TagGroupStories.MaximalProps} />
+
+### Links
+
+Tags can also be links. Tags with an `href` are not selectable.
+
+<Canvas of={TagGroupStories.Links} />
+
+### Custom Remove Button
+
+Custom remove buttons relative to each tag can be obtained by passing a `removeButtonProps` prop to the `Tag` component instead of a global `removeButtonProps` prop passed to the `TagGroup` component.
+
+<Canvas of={TagGroupStories.CustomRemoveButton} />

--- a/libs/stack/stack-ui/src/components/TagGroup/tag-group.stories.jsx
+++ b/libs/stack/stack-ui/src/components/TagGroup/tag-group.stories.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useListData } from 'react-stately'
 import Box from '../Box'
 import Typography from '../Typography'
@@ -16,25 +16,32 @@ const TemplateRemovable = (args) => {
   return <TagGroup {...rest} items={list.items} onRemove={(keys) => list.remove(...keys)} />
 }
 
-const TemplateMaximalProps = (args) => {
+/**
+ *
+ * @param {import('./interface').TTagGroupProps} args
+ * @returns
+ */
+function TemplateMaximalProps(args) {
   const { items, defaultSelectedKeys, ...rest } = args
   const list = useListData({ initialItems: items, initialSelectedKeys: defaultSelectedKeys })
+  const selectedKeysRender = useMemo(() => {
+    return Array.from(list.selectedKeys?.keys?.() ?? []).map((key) => (
+      <Box customTheme="rounded-full bg-color-1-800 text-white px-2 py-1" key={key}>
+        {list.getItem(key)?.children}
+      </Box>
+    ))
+  }, [list])
   return (
     <Box>
       <Typography tokens={{ size: 'h3' }}>Current selection</Typography>
-      <Box customTheme="flex flex-wrap gap-2">
-        {Array.from(list.selectedKeys).map((key) => (
-          <Box customTheme="rounded-full bg-color-1-800 text-white px-2 py-1" key={key}>
-            {list.getItem(key)?.children}
-          </Box>
-        ))}
-      </Box>
+      <Box customTheme="flex flex-wrap gap-2">{selectedKeysRender}</Box>
       <TagGroup
         {...rest}
         defaultSelectedKeys={defaultSelectedKeys}
         items={list.items}
-        onSelectionChange={(keys) => list.setSelectedKeys(keys)}
-        onRemove={(keys) => list.remove(...keys)}
+        selectedKeys={list.selectedKeys}
+        onSelectionChange={list.setSelectedKeys}
+        onRemove={list.remove}
       />
     </Box>
   )
@@ -71,8 +78,14 @@ const meta = {
     layout: 'padded',
   },
   argTypes: {
+    label: {
+      description: 'Label of the tag group. Gets rendered before the tags.',
+    },
+    description: {
+      description: 'Description of the tag group. Gets rendered after the tags.',
+    },
     removeButtonProps: {
-      control: 'none',
+      control: false,
       description:
         'Acts as a default for the remove button of all tags. Individual tags `props.item.props.removeButtonProps` take precedence.',
       table: {
@@ -119,12 +132,14 @@ const meta = {
       table: {
         type: { summary: '(keys: Set<Key>) => void' },
       },
+      control: false,
     },
     onSelectionChange: {
       description: 'Callback when a tag is selected.',
       table: {
         type: { summary: '(keys: "all" | Set<Key>) => void' },
       },
+      control: false,
     },
     errorMessage: {
       description:
@@ -139,6 +154,7 @@ const meta = {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' },
       },
+      control: { type: 'boolean' },
     },
     selectedKeys: {
       description: 'The keys of the selected tags. Use for controlled selection along with `onSelectionChange`.',

--- a/libs/stack/stack-ui/src/components/TagGroup/tag-group.stories.jsx
+++ b/libs/stack/stack-ui/src/components/TagGroup/tag-group.stories.jsx
@@ -1,0 +1,274 @@
+import { useState } from 'react'
+import { useListData } from 'react-stately'
+import Box from '../Box'
+import Typography from '../Typography'
+import Tag from './components/Tag'
+import { TagItem } from './components/TagItem'
+import TagGroup from '.'
+/**
+ * @typedef {import('@storybook/react').Meta<typeof TagGroup>} Meta
+ * @typedef {import('@storybook/react').StoryObj<Meta>} Story
+ */
+
+const TemplateRemovable = (args) => {
+  const { items, ...rest } = args
+  const list = useListData({ initialItems: items })
+  return <TagGroup {...rest} items={list.items} onRemove={(keys) => list.remove(...keys)} />
+}
+
+const TemplateMaximalProps = (args) => {
+  const { items, defaultSelectedKeys, ...rest } = args
+  const list = useListData({ initialItems: items, initialSelectedKeys: defaultSelectedKeys })
+  return (
+    <Box>
+      <Typography tokens={{ size: 'h3' }}>Current selection</Typography>
+      <Box customTheme="flex flex-wrap gap-2">
+        {Array.from(list.selectedKeys).map((key) => (
+          <Box customTheme="rounded-full bg-color-1-800 text-white px-2 py-1" key={key}>
+            {list.getItem(key)?.children}
+          </Box>
+        ))}
+      </Box>
+      <TagGroup
+        {...rest}
+        defaultSelectedKeys={defaultSelectedKeys}
+        items={list.items}
+        onSelectionChange={(keys) => list.setSelectedKeys(keys)}
+        onRemove={(keys) => list.remove(...keys)}
+      />
+    </Box>
+  )
+}
+
+const TemplateErrorMessage = (args) => {
+  const { items, ...rest } = args
+  const list = useListData({ initialItems: items })
+  const errorMessageData = 'You must select at least one tag'
+  const [errorMessage, setErrorMessage] = useState(errorMessageData)
+  return (
+    <TagGroup
+      {...rest}
+      items={list.items}
+      onSelectionChange={(keys) => {
+        list.setSelectedKeys(keys)
+        setErrorMessage(keys.size === 0 ? errorMessageData : undefined)
+      }}
+      errorMessage={errorMessage}
+    />
+  )
+}
+
+/**
+ * @type {Meta}
+ */
+const meta = {
+  title: 'Base Components/TagGroup',
+  component: TagGroup,
+  subcomponents: {
+    Tag,
+  },
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    removeButtonProps: {
+      control: 'none',
+      description:
+        'Acts as a default for the remove button of all tags. Individual tags `props.item.props.removeButtonProps` take precedence.',
+      table: {
+        type: { summary: 'TButtonProps' },
+        defaultValue: { summary: '{children: "❌"}' },
+      },
+    },
+    selectionMode: {
+      control: 'select',
+      options: ['single', 'multiple'],
+      table: {
+        type: { summary: 'single | multiple | none' },
+        defaultValue: { summary: 'multiple' },
+      },
+    },
+    selectionBehavior: {
+      control: 'select',
+      options: ['toggle', 'replace'],
+      description:
+        'Behavior of the selection. `replace` will make the group behave like a radio group, as opposed to `toggle` that will behave like a checkbox group.',
+      table: {
+        defaultValue: { summary: 'toggle' },
+        type: { summary: 'toggle | replace' },
+      },
+    },
+    items: {
+      table: {
+        type: { summary: 'TTagItemProps[]' },
+      },
+    },
+    children: {
+      description:
+        'Children containing items data, or a rendering function. You can either use the `items` prop with the `children` rendering function or pass the data in `children` directly.',
+      table: {
+        type: {
+          summary:
+            'ReactElement<TTagItemProps> | ReactElement<TTagItemProps>[] | ((item: TTagItemProps) => ReactElement<TTagItemProps>)',
+        },
+      },
+      control: 'none',
+    },
+    onRemove: {
+      description: 'Callback when a tag is removed. If passed, all tags will receive `allowRemoving: true`',
+      table: {
+        type: { summary: '(keys: Set<Key>) => void' },
+      },
+    },
+    onSelectionChange: {
+      description: 'Callback when a tag is selected.',
+      table: {
+        type: { summary: '(keys: "all" | Set<Key>) => void' },
+      },
+    },
+    errorMessage: {
+      description:
+        'The TagGroup component itself does not do any validation concerning errors. If the error message is passed, it will necessarily be displayed. Control over if the error message is displayed or not must be done externally.',
+      table: {
+        type: { summary: 'string | undefined' },
+      },
+    },
+    disallowEmptySelection: {
+      description: 'Disables selecting the last selected tag, if there are any selected.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    selectedKeys: {
+      description: 'The keys of the selected tags. Use for controlled selection along with `onSelectionChange`.',
+      table: {
+        type: { summary: 'Set<Key>' },
+      },
+    },
+    defaultSelectedKeys: {
+      description: 'Tags that are selected by default.',
+      table: {
+        type: { summary: 'Set<Key>' },
+      },
+    },
+    disabledKeys: {
+      description: 'Tags that are disabled. Can be styled using the `isDisabled` token.',
+      table: {
+        type: { summary: 'Set<Key>' },
+      },
+    },
+  },
+  args: {
+    label: 'Places to visit',
+    removeButtonProps: { children: '❌' },
+    children: [
+      <TagItem key="china">China</TagItem>,
+      <TagItem key="japan">Japan</TagItem>,
+      <TagItem key="korea">Korea</TagItem>,
+    ],
+  },
+}
+
+export default meta
+
+/**
+ * @type {Story}
+ */
+export const Default = {}
+
+/**
+ * @type {Story}
+ */
+export const Removable = {
+  render: TemplateRemovable,
+  args: {
+    items: [
+      { key: 'china', children: 'China' },
+      { key: 'japan', children: 'Japan' },
+      { key: 'korea', children: 'Korea' },
+    ],
+    children: (item) => <TagItem {...item} key={item.key} />,
+  },
+}
+
+/**
+ * @type {Story}
+ */
+export const Selectable = {
+  args: {
+    selectionMode: 'multiple',
+  },
+}
+
+/**
+ * @type {Story}
+ */
+export const ErrorMessage = {
+  render: TemplateErrorMessage,
+  args: {
+    disallowEmptySelection: true,
+    selectionMode: 'multiple',
+  },
+}
+
+/**
+ * @type {Story}
+ */
+export const MaximalProps = {
+  name: 'Maximal Props (Controlled)',
+  render: TemplateMaximalProps,
+  args: {
+    items: [
+      { key: 'china', children: 'China' },
+      { key: 'japan', children: 'Japan' },
+      { key: 'korea', children: 'Korea' },
+      { key: 'france', children: 'France' },
+      { key: 'italy', children: 'Italy' },
+      { key: 'spain', children: 'Spain' },
+      { key: 'germany', children: 'Germany' },
+      { key: 'portugal', children: 'Portugal' },
+      { key: 'greece', children: 'Greece' },
+    ],
+    children: (item) => <TagItem {...item} key={item.key} />,
+    selectionMode: 'multiple',
+    description: 'Select the places you want to visit',
+    disabledKeys: ['italy', 'germany'],
+    defaultSelectedKeys: ['china', 'japan'],
+  },
+}
+
+/**
+ * @type {Story}
+ */
+export const Links = {
+  args: {
+    label: 'Navigate to your favorite places',
+    children: [
+      <TagItem key="china" href="https://www.china.com">
+        China
+      </TagItem>,
+      <TagItem key="japan" href="https://www.japan.com">
+        Japan
+      </TagItem>,
+      <TagItem key="korea" href="https://www.korea.com">
+        Korea
+      </TagItem>,
+    ],
+  },
+}
+
+/**
+ * @type {Story}
+ */
+export const CustomRemoveButton = {
+  render: TemplateRemovable,
+  args: {
+    items: [
+      { key: 'china', children: 'China', removeButtonProps: { children: '🔴' } },
+      { key: 'japan', children: 'Japan', removeButtonProps: { children: '⚠️' } },
+      { key: 'korea', children: 'Korea' },
+    ],
+    children: (item) => <TagItem {...item} key={item.key} />,
+  },
+}

--- a/libs/stack/stack-ui/src/theme/TagGroup/index.ts
+++ b/libs/stack/stack-ui/src/theme/TagGroup/index.ts
@@ -1,0 +1,120 @@
+import { tv } from 'tailwind-variants'
+import typography from '../Typography'
+
+const tagGroupWrapper = tv({
+  base: `
+    flex
+    flex-col
+    gap-4
+  `,
+})
+
+const tagGroupTags = tv({
+  base: `
+    w-full
+    flex
+    flex-wrap
+    gap-2
+  `,
+})
+
+const tagGroupLabel = tv({
+  extend: typography,
+  defaultVariants: {
+    size: 'h4',
+  },
+})
+
+const tagGroupDescription = tv({
+  extend: typography,
+  defaultVariants: {
+    size: 'paragraph',
+  },
+})
+
+const tagGroupErrorMessage = tv({
+  extend: typography,
+  defaultVariants: {
+    size: 'paragraph',
+    isError: true,
+  },
+})
+
+const tagGroupTagWrapper = tv({
+  base: `
+    focus-visible:outline
+    focus-visible:outline-offset-2
+    focus-visible:outline-2
+    focus-visible:outline-black
+    cursor-pointer
+    transition-all
+    duration-200
+  `,
+  variants: {
+    isSelected: {
+      true: `bg-color-1-800 text-white`,
+    },
+    isDisabled: {
+      true: `opacity-50 pointer-events-none`,
+    },
+    isLink: {
+      true: `
+        border-b
+        border-color-1-300
+        px-2
+        py-0.5
+        mx-2
+        text-color-1-500
+        hover:text-color-1-700
+        hover:border-color-1-700
+        active:text-color-1-900
+        active:border-color-1-900
+      `,
+      false: `
+        p-2
+        bg-color-1-200
+        rounded-full
+        hover:bg-color-1-300
+        active:bg-color-1-400
+        active:text-white
+      `,
+    },
+  },
+  defaultVariants: {
+    isLink: false,
+  },
+})
+
+const tagGroupTagContainer = tv({
+  base: `
+    flex
+    items-center
+    gap-2
+  `,
+})
+
+const tagGroupTagRemoveButton = tv({
+  base: `
+    aspect-square
+    rounded-full
+    bg-black/30
+    p-1
+    h-auto
+    w-8
+  `,
+})
+
+const tagGroupTheme = {
+  wrapper: tagGroupWrapper,
+  tags: tagGroupTags,
+  label: tagGroupLabel,
+  description: tagGroupDescription,
+  errorMessage: tagGroupErrorMessage,
+  tag: {
+    wrapper: tagGroupTagWrapper,
+    container: tagGroupTagContainer,
+    removeButton: tagGroupTagRemoveButton,
+  },
+}
+
+export default tagGroupTheme

--- a/libs/stack/stack-ui/src/theme/index.tsx
+++ b/libs/stack/stack-ui/src/theme/index.tsx
@@ -45,6 +45,7 @@ import {
   shareButtonLinksList,
 } from './ShareButton'
 import { sidePanelWrapper, sidePanelContainer, sidePanelInnerContainer } from './SidePanel'
+import tagGroupTheme from './TagGroup'
 import { textArea } from './TextArea'
 import typography from './Typography'
 
@@ -178,6 +179,7 @@ const BaseTheme = makeTheme({
   },
   img: imgTheme,
   alerts: alertsTheme,
+  tagGroup: tagGroupTheme,
 })
 
 export default React.memo(createThemeProvider(BaseTheme))


### PR DESCRIPTION
## Issue
https://okamca.atlassian.net/browse/STACK-275

## Implementation details
### Components
- [x] TagGroup should be implemented with best practices from react-aria
- [x] Tag should be implemented with best practices from react-aria
- [x] Both components should be fully themeable
  - [x] Each subcomponent should have a `themeName`
  - [x] Each subcomponent should receive `tokens`
- [x] Components should pass "state tokens" to their children (like isSelected, isDisabled, etc)

### Documentation
- [x] Should have a controlled state story
- [x] Should have a tag as links story
- [x] Should have a story displaying disabled state
- [x] Should have a story disaplying error message
- [x] Should document most props (especially custom props not from react aria)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a TagGroup component for managing and displaying groups of tags, supporting accessibility, theming, and removable tags.
	- Added Tag and TagItem components for flexible tag rendering and collection management.
	- Included custom theming support for TagGroup and tags, with new theme variants.
- **Documentation**
	- Added comprehensive Storybook stories and MDX documentation for TagGroup, showcasing usage, props, and customization options.
- **Bug Fixes**
	- Improved Button component to prevent unknown attribute errors in the DOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->