### PR TITLE
fix: dont display x icon if custom icon is passed as param

### DIFF
--- a/libs/stack/stack-ui/package.json
+++ b/libs/stack/stack-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okam/stack-ui",
   "main": "./index.js",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "types": "./index.d.ts",
   "exports": {
     ".": {

--- a/libs/stack/stack-ui/src/components/fields/SearchField/index.tsx
+++ b/libs/stack/stack-ui/src/components/fields/SearchField/index.tsx
@@ -13,6 +13,14 @@ import Search from '../../icons/Search'
 import Typography from '../../Typography'
 import type TSearchProps from './interface'
 
+const BuiltinIcon = ({ value }: { value: string }) => {
+  if (value === '') {
+    return <Search width="16" height="16" />
+  }
+
+  return <Close width="16" height="16" />
+}
+
 const SearchField = <T extends TToken>(props: TSearchProps<T>) => {
   const { setUserSearchQuery } = useUserQueryValHook()
   const {
@@ -71,7 +79,8 @@ const SearchField = <T extends TToken>(props: TSearchProps<T>) => {
             themeName={`${themeName}.icon`}
             aria-label="clear"
           >
-            {icon ?? (state.value === '' ? <Search width="16" height="16" /> : <Close width="16" height="16" />)}
+            {icon == null && <BuiltinIcon value={state.value} />}
+            {icon != null && icon}
           </Button>
         </FocusRing>
       </Box>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for displaying icons in the search field's clear button, ensuring the appropriate icon appears based on input state. No changes to the component's public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->