### PR TITLE
STACK-287 - Add support for conditional rendering of buttons in Lightbox component

### DIFF
--- a/libs/stack/stack-ui/src/components/Lightbox/index.tsx
+++ b/libs/stack/stack-ui/src/components/Lightbox/index.tsx
@@ -48,7 +48,7 @@ const Lightbox = <T extends TToken>(props: TLightboxProps<T>) => {
         <FocusRing focusRingClass="has-focus-ring" within>
           <Button themeName={`${themeName}.wrapper`} tokens={tokens} {...openTriggerProps}>
             {label && (
-              <Typography themeName={`${themeName}.label`} tokens={{ size: 'footnotes' }} {...labelProps}>
+              <Typography themeName={`${themeName}.label`} tokens={tokens} {...labelProps}>
                 {label}
               </Typography>
             )}

--- a/libs/stack/stack-ui/src/components/Lightbox/index.tsx
+++ b/libs/stack/stack-ui/src/components/Lightbox/index.tsx
@@ -31,6 +31,8 @@ const Lightbox = <T extends TToken>(props: TLightboxProps<T>) => {
     closeButton: CloseButton = LightboxCloseButton,
     closeButtonAriaLabel,
     transitionComponent,
+    showTriggerButton = true,
+    showCloseButton = true,
   } = props
 
   const state = useOverlayTriggerState(props)
@@ -42,16 +44,18 @@ const Lightbox = <T extends TToken>(props: TLightboxProps<T>) => {
 
   return (
     <>
-      <FocusRing focusRingClass="has-focus-ring" within>
-        <Button themeName={`${themeName}.wrapper`} tokens={tokens} {...openTriggerProps}>
-          {label && (
-            <Typography themeName={`${themeName}.label`} tokens={{ size: 'footnotes' }} {...labelProps}>
-              {label}
-            </Typography>
-          )}
-          {thumbnailContent}
-        </Button>
-      </FocusRing>
+      {showTriggerButton && (
+        <FocusRing focusRingClass="has-focus-ring" within>
+          <Button themeName={`${themeName}.wrapper`} tokens={tokens} {...openTriggerProps}>
+            {label && (
+              <Typography themeName={`${themeName}.label`} tokens={{ size: 'footnotes' }} {...labelProps}>
+                {label}
+              </Typography>
+            )}
+            {thumbnailContent}
+          </Button>
+        </FocusRing>
+      )}
       <Modal
         themeName={`${themeName}.modal`}
         tokens={tokens}
@@ -59,12 +63,14 @@ const Lightbox = <T extends TToken>(props: TLightboxProps<T>) => {
         {...overlayProps}
         transitionComponent={transitionComponent}
       >
-        <CloseButton
-          themeName={`${themeName}.closeBtn`}
-          tokens={tokens}
-          aria-label={closeButtonAriaLabel}
-          {...triggerProps}
-        />
+        {showCloseButton && (
+          <CloseButton
+            themeName={`${themeName}.closeBtn`}
+            tokens={tokens}
+            aria-label={closeButtonAriaLabel}
+            {...triggerProps}
+          />
+        )}
         <Box themeName={`${themeName}.container`} tokens={tokens}>
           {children}
         </Box>

--- a/libs/stack/stack-ui/src/components/Lightbox/interface.ts
+++ b/libs/stack/stack-ui/src/components/Lightbox/interface.ts
@@ -19,6 +19,8 @@ export interface LightboxProps<T = TToken>
   setOpen?: Dispatch<SetStateAction<boolean>>
   closeButton?: TCloseButtonProps
   transitionComponent?: FunctionComponent<TTransition>
+  showTriggerButton?: boolean
+  showCloseButton?: boolean
 }
 
 export interface TLightboxProps<T = TToken> extends LightboxProps<T> {

--- a/libs/stack/stack-ui/src/components/Lightbox/lightbox.mdx
+++ b/libs/stack/stack-ui/src/components/Lightbox/lightbox.mdx
@@ -43,3 +43,42 @@ export const TemplateControlledState = (args) => {
 <Canvas>
   <Story of={LightboxStories.ControlledState} />
 </Canvas>
+
+### With hidden buttons in controlled state
+
+<Canvas>
+  <Story of={LightboxStories.ControlledStateHiddenButtons} />
+</Canvas>
+
+## Conditional Rendering
+
+The Lightbox component supports conditional rendering of trigger and close buttons through the `showTriggerButton` and `showCloseButton` props. These features are particularly useful in controlled state scenarios.
+
+### Examples:
+
+- Hide trigger button: `<Lightbox showTriggerButton={false} />`  
+  Use when you want to provide your own custom trigger mechanism.
+
+- Hide close button: `<Lightbox showCloseButton={false} />`  
+  Use when you want to implement your own close mechanism or need a modal without a close button.
+
+- Controlled state with hidden buttons:
+```jsx
+const [isOpen, setOpen] = useState(false);
+
+return (
+  <>
+    <Button handlePress={() => setOpen(true)}>Custom Trigger</Button>
+    <Lightbox 
+      isOpen={isOpen} 
+      onOpenChange={setOpen}
+      showTriggerButton={false} 
+      showCloseButton={false}
+      // ...other props
+    >
+      {content}
+      <Button handlePress={() => setOpen(false)}>Custom Close</Button>
+    </Lightbox>
+  </>
+)
+```

--- a/libs/stack/stack-ui/src/components/Lightbox/lightbox.stories.jsx
+++ b/libs/stack/stack-ui/src/components/Lightbox/lightbox.stories.jsx
@@ -60,6 +60,24 @@ export default {
     setOpen: {
       description: `Allows the lightbox component's thumbnail to still controll the lightbox's state even in a case of controlled state`,
     },
+
+    showTriggerButton: {
+      description:
+        'Controls visibility of the trigger button. Useful in controlled state scenarios where you might want to provide your own trigger. Defaults to true.',
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true,
+    },
+
+    showCloseButton: {
+      description:
+        'Controls visibility of the close button. Useful in controlled state scenarios where you might want to handle closing differently. Defaults to true.',
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true,
+    },
   },
 
   args: {
@@ -78,4 +96,13 @@ export const Default = {
 export const ControlledState = {
   render: TemplateControlledState.bind({}),
   name: 'ControlledState',
+}
+
+export const ControlledStateHiddenButtons = {
+  render: TemplateControlledState.bind({}),
+  name: 'Controlled State with Hidden Buttons',
+  args: {
+    showTriggerButton: false,
+    showCloseButton: false,
+  },
 }

--- a/libs/stack/stack-ui/src/storybook/Lightbox/LightboxControlledState.tsx
+++ b/libs/stack/stack-ui/src/storybook/Lightbox/LightboxControlledState.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
+import Box from '../../components/Box'
 import Button from '../../components/Button'
 import type { TButtonProps } from '../../components/Button/interface'
 import Lightbox from '../../components/Lightbox'
 import type { TLightboxProps } from '../../components/Lightbox/interface'
 
 const LightboxControlledState = (props: TLightboxProps) => {
-  const { children, ...rest } = props
+  const { children, showTriggerButton = true, showCloseButton = true, ...rest } = props
 
   const [isOpen, setOpen] = useState(false)
 
@@ -30,8 +31,15 @@ const LightboxControlledState = (props: TLightboxProps) => {
         setOpen={setOpen}
         closeButton={closeButtonRender}
         onOpenChange={() => setOpen(!isOpen)}
+        showTriggerButton={showTriggerButton}
+        showCloseButton={showCloseButton}
       >
         {children}
+        {!showCloseButton && (
+          <Box themeName="mt-4">
+            <Button handlePress={() => setOpen(false)}>Custom Close Button</Button>
+          </Box>
+        )}
       </Lightbox>
     </>
   )


### PR DESCRIPTION
## Issue Link
Closes #287

## Implementation details
- [x] Added `showTriggerButton` and `showCloseButton` props to Lightbox component interface
- [x] Implemented conditional rendering of trigger button based on `showTriggerButton` prop
- [x] Implemented conditional rendering of close button based on `showCloseButton` prop
- [x] Added documentation and examples for the new props
- [x] Created a new story example demonstrating hidden buttons in controlled state

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
1. Run Storybook locally and navigate to the Lightbox component
2. Test default behavior with both buttons visible
3. Test controlled state with hidden trigger button (see "Controlled State with Hidden Buttons" example)
4. Test controlled state with hidden close button (see "Controlled State with Hidden Buttons" example)
5. Verify the custom close button appears when the default close button is hidden
6. Verify all functionality works correctly in each scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to the Lightbox component to show or hide the trigger and close buttons.
- **Documentation**
  - Updated documentation and examples to demonstrate how to customize the visibility of Lightbox buttons.
- **Style**
  - Enhanced Storybook controls to allow toggling the visibility of Lightbox buttons in demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->