### PR TITLE
313-combobox---clear-button-doesnt-worrk

### DIFF
--- a/libs/stack/stack-ui/src/components/fields/ComboBox/combo-box.stories.tsx
+++ b/libs/stack/stack-ui/src/components/fields/ComboBox/combo-box.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof ComboBox> = {
     label: 'Brand',
     placeholder: 'Select a brand',
     allowsCustomValue: true,
-    menuTrigger: 'focus',
+    menuTrigger: 'input',
     children: [
       <Item key="1">CTV</Item>,
       <Item key="2">TSN</Item>,

--- a/libs/stack/stack-ui/src/components/fields/ComboBox/components/ComboBoxButton.tsx
+++ b/libs/stack/stack-ui/src/components/fields/ComboBox/components/ComboBoxButton.tsx
@@ -1,0 +1,22 @@
+import type { PressEvent } from '@react-types/shared'
+import { forwardRef, useCallback } from 'react'
+import { ButtonWithForwardRef } from '../../../Button'
+import type { TComboBoxButtonProps } from '../interface'
+
+const ComboBoxButton = forwardRef<HTMLButtonElement & HTMLAnchorElement, TComboBoxButtonProps>((props, ref) => {
+  const { state, handlePress: handlePressProp, ...rest } = props
+
+  const handlePress = useCallback(
+    (e: PressEvent) => {
+      state.setInputValue('')
+      state.selectionManager.clearSelection()
+      handlePressProp?.(e)
+    },
+    [handlePressProp, state],
+  )
+
+  return <ButtonWithForwardRef {...rest} ref={ref} handlePress={handlePress} />
+})
+ComboBoxButton.displayName = 'ComboBoxButton'
+
+export default ComboBoxButton

--- a/libs/stack/stack-ui/src/components/fields/ComboBox/index.tsx
+++ b/libs/stack/stack-ui/src/components/fields/ComboBox/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type { PressEvent } from '@react-types/shared'
 import { isEmpty } from 'radashi'
 import React, { useRef, useCallback, useMemo } from 'react'
 import { useComboBox, useFilter } from 'react-aria'
@@ -8,16 +7,17 @@ import type { RegisterOptions } from 'react-hook-form'
 import { useFormContext, Controller } from 'react-hook-form'
 import { useComboBoxState } from 'react-stately'
 import { useDebounce } from '../../../hooks/useDebounce'
+import useThemeContext from '../../../providers/Theme/hooks'
 import type { TToken } from '../../../providers/Theme/interface'
 import { useTranslation } from '../../../providers/Translation'
 import Box, { BoxWithForwardRef } from '../../Box'
-import { ButtonWithForwardRef } from '../../Button'
 import Icon from '../../Icon'
 import ArrowDown from '../../icons/ArrowDown'
 import CloseBtn from '../../icons/CloseBtn'
 import Popover from '../../Popover'
 import Typography from '../../Typography'
 import { ControlledListBox } from '../ListBox'
+import ComboBoxButton from './components/ComboBoxButton'
 import type { TComboBoxProps } from './interface'
 
 const ComboBox = (props: TComboBoxProps<object, TToken>) => {
@@ -97,25 +97,6 @@ const ComboBox = (props: TComboBoxProps<object, TToken>) => {
     isRequired,
   }
 
-  const handleButtonPress = useCallback(
-    (e: PressEvent) => {
-      if (hasValue) {
-        // Clear functionality: clear both input value and selection
-        state.setInputValue('')
-        state.selectionManager.clearSelection()
-        // Focus back to the input after clearing
-        if (inputRef.current) {
-          inputRef.current.focus()
-        }
-      } else {
-        // Default dropdown toggle functionality - call both handlers like Select does
-        onPress?.(e)
-        onPressStart?.(e)
-      }
-    },
-    [hasValue, state, onPress, onPressStart, inputRef],
-  )
-
   const handleInputRef = useCallback(
     (ref: HTMLInputElement | null) => {
       if (ref) {
@@ -133,6 +114,8 @@ const ComboBox = (props: TComboBoxProps<object, TToken>) => {
     return state.inputValue
   }, [selectedItem, state.inputValue, isOpen])
 
+  const inputTheme = useThemeContext(`${themeName}.input`, tokens)
+
   return (
     <Box themeName={`${themeName}.wrapper`} tokens={comboBoxTokens} customTheme={customTheme}>
       {label && (
@@ -142,16 +125,20 @@ const ComboBox = (props: TComboBoxProps<object, TToken>) => {
       )}
       <Box themeName={`${themeName}.container`}>
         <BoxWithForwardRef ref={inputWrapperRef} themeName={`${themeName}.inputWrapper`} tokens={comboBoxTokens}>
-          <input {...inputProps} ref={handleInputRef} value={displayValue} />
-          <ButtonWithForwardRef
+          <input {...inputProps} ref={handleInputRef} value={displayValue} className={inputTheme} />
+          <ComboBoxButton
+            state={state}
             themeName={`${themeName}.button`}
             tokens={comboBoxTokens}
             {...restOfButtonProps}
             ref={buttonRef}
-            handlePress={handleButtonPress}
+            handlePress={(e) => {
+              onPress?.(e)
+              onPressStart?.(e)
+            }}
           >
             <Icon themeName={`${themeName}.icon`} tokens={comboBoxTokens} icon={hasValue ? closeIcon : icon} />
-          </ButtonWithForwardRef>
+          </ComboBoxButton>
         </BoxWithForwardRef>
         {isOpen && inputWrapperRef.current && debouncedState.collection.size > 0 && (
           <Popover

--- a/libs/stack/stack-ui/src/components/fields/ComboBox/interface.ts
+++ b/libs/stack/stack-ui/src/components/fields/ComboBox/interface.ts
@@ -1,10 +1,11 @@
 import type { ReactNode, RefObject } from 'react'
 import type { AriaComboBoxOptions } from 'react-aria'
 import type { RefCallBack } from 'react-hook-form'
-import type { ComboBoxStateOptions } from 'react-stately'
+import type { ComboBoxState, ComboBoxStateOptions } from 'react-stately'
 import type { TToken } from '../../../providers/Theme/interface'
 import type { TDefaultComponent, TReactHookForm } from '../../../types/components'
 import type { TDefaultNodeComponent } from '../../../types/react-stately'
+import type { TButtonProps } from '../../Button/interface'
 
 export type TFieldReactHookForm<T = TToken> = TReactHookForm & Omit<TDefaultComponent<T>, 'children'>
 
@@ -26,4 +27,8 @@ export interface TComboBoxProps<I extends object = object, T extends TToken = TT
    * @default 200
    */
   debounceDelay?: number
+}
+
+export interface TComboBoxButtonProps<T extends TToken = TToken> extends TButtonProps<T> {
+  state: ComboBoxState<object & TDefaultNodeComponent<object, TToken>>
 }

--- a/libs/stack/stack-ui/src/theme/ComboBox/index.ts
+++ b/libs/stack/stack-ui/src/theme/ComboBox/index.ts
@@ -1,7 +1,26 @@
+import { tv } from 'tailwind-variants'
 import type { TTheme } from '../../providers/Theme/interface'
 import button from '../Button'
 import listBoxTheme from '../ListBox'
 import typography from '../Typography'
+
+const comboBoxButton = tv({
+  base: [
+    button.base,
+    `
+      px-4
+      py-2
+      text-white
+      bg-color-1-500
+    `,
+  ],
+  variants: {
+    isOpen: {
+      true: 'pointer-events-none',
+      false: 'hover:bg-color-1-400 active:bg-color-1-400',
+    },
+  },
+})
 
 const comboBoxTheme: TTheme = {
   wrapper: () => 'flex flex-col gap-4 relative',
@@ -9,7 +28,7 @@ const comboBoxTheme: TTheme = {
   container: () => 'flex flex-col gap-4',
   inputWrapper: () =>
     'relative flex items-center outline outline-2 outline-gray-300 focus-within:outline focus-within:outline-black focus-within:outline-2 [&>input]:flex-1 [&>input]:min-w-0 [&>input]:pr-10 [&>input]:border-0 [&>input]:outline-0 [&>input]:bg-transparent [&>input]:text-ellipsis [&>input]:whitespace-nowrap [&>input]:overflow-hidden',
-  button: (props) => button(props),
+  button: comboBoxButton,
   popover: {
     popover: () =>
       'w-[var(--comboBox-popover-container-width)] max-h-[300px] overflow-y-auto overflow-x-hidden text-white !bg-color-1-500 rounded-md p-2',


### PR DESCRIPTION
## Issue
Closes #313

## Implementation details
- [x] Clear button should always clear input value (when the input value isn't a part of the pre-defined options and vice-versa)
- [x] Clear button hover styles should not change when hovering it while the popover is open

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated ComboBox button component with improved interaction handling.
  * Added theme-based styling for the ComboBox button, including new visual variants.

* **Style**
  * Updated ComboBox input and button to use theme-derived styles for a more consistent appearance.

* **Bug Fixes**
  * Adjusted ComboBox menu behaviour to open on user input instead of focus for enhanced usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->