### PR TITLE
Icon props are missing from exports

### DIFF
--- a/libs/stack/stack-ui/src/index.ts
+++ b/libs/stack/stack-ui/src/index.ts
@@ -106,6 +106,7 @@ export type {
 } from './types/react-stately'
 export type { TListBoxProps, TListBoxSectionProps } from './components/fields/ListBox/interface'
 export type { TOptionProps } from './components/fields/Option/interface'
+export type { TIconProps } from './components/Icon/interface'
 
 // utils
 export { default as generateUtmTags } from './components/ShareButton/utils/generateUtmTags'


### PR DESCRIPTION
Fixes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added export of the `TIconProps` type to improve type accessibility for users of the UI library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->