### PR TITLE
ShareButton - fallback to window.location.href doesn't work

### DIFF
--- a/libs/stack/stack-ui/src/components/ShareButton/utils/useFacebookShareUrl.ts
+++ b/libs/stack/stack-ui/src/components/ShareButton/utils/useFacebookShareUrl.ts
@@ -6,7 +6,7 @@ import useWindow from './useWindow'
 const useFacebookShareUrl = (media: string, medium: string, urlToShare: string) => {
   const { windowLocation, windowTitle } = useWindow()
 
-  const currentURL = urlToShare ?? windowLocation
+  const currentURL = urlToShare || windowLocation
   const utm = generateUtmTags(media, medium)
   const fullUrl = `${currentURL}${utm}`
   return `https://www.facebook.com/sharer.php?u=${fullUrl}&t=${windowTitle}`

--- a/libs/stack/stack-ui/src/components/ShareButton/utils/useLinkedinShareUrl.ts
+++ b/libs/stack/stack-ui/src/components/ShareButton/utils/useLinkedinShareUrl.ts
@@ -6,7 +6,7 @@ import useWindow from './useWindow'
 const useLinkedinShareUrl = (media: string, medium: string, urlToShare: string) => {
   const { windowLocation } = useWindow()
 
-  const currentURL = urlToShare ?? windowLocation
+  const currentURL = urlToShare || windowLocation
   const utm = generateUtmTags(media, medium)
   const fullUrl = `${currentURL}${utm}`
   return `https://www.linkedin.com/shareArticle?mini=true&url=${fullUrl}`

--- a/libs/stack/stack-ui/src/components/ShareButton/utils/useMailToShareUrl.ts
+++ b/libs/stack/stack-ui/src/components/ShareButton/utils/useMailToShareUrl.ts
@@ -6,7 +6,7 @@ import useWindow from './useWindow'
 const useMailToShareUrl = (media: string, medium: string, urlToShare: string) => {
   const { windowLocation, windowTitle } = useWindow()
 
-  const currentURL = urlToShare ?? windowLocation
+  const currentURL = urlToShare || windowLocation
   const utm = generateUtmTags(media, medium)
   const fullUrl = `${currentURL}${utm}`
   return `mailto:?to=&body=${windowTitle}%20${fullUrl}`

--- a/libs/stack/stack-ui/src/components/ShareButton/utils/useXShareUrl.ts
+++ b/libs/stack/stack-ui/src/components/ShareButton/utils/useXShareUrl.ts
@@ -6,7 +6,7 @@ import useWindow from './useWindow'
 const useXShareUrl = (media: string, medium: string, textParam: string, urlToShare: string) => {
   const { windowLocation } = useWindow()
 
-  const currentURL = urlToShare ?? windowLocation
+  const currentURL = urlToShare || windowLocation
   const utm = generateUtmTags(media, medium)
   const fullUrl = `${currentURL}${utm}`
   return `https://X.com/intent/tweet/?text=${textParam}&url=${fullUrl}`


### PR DESCRIPTION
Fixes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL selection logic in social sharing features to reliably fall back to the current page URL when necessary, ensuring consistent behaviour across Facebook, LinkedIn, Email, and X sharing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->