### PR TITLE
fix(directus-next): remove server-only

### DIFF
--- a/libs/directus/directus-next/package.json
+++ b/libs/directus/directus-next/package.json
@@ -40,7 +40,6 @@
     "next": "^15.0.0",
     "radashi": "^12.3.0",
     "@okam/directus-query": "1.4.2",
-    "server-only": "0.0.1",
     "graphql-request": "^7.1.2",
     "@graphql-typed-document-node/core": "3.2.0",
     "zod": "^4.3.5"

--- a/libs/directus/directus-next/src/pageSettings/context.ts
+++ b/libs/directus/directus-next/src/pageSettings/context.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable react-hooks/rules-of-hooks */
-import 'server-only'
 import { createServerContext } from '@okam/next-component/server'
 import type { Variables } from 'graphql-request'
 import type { TPageSettingsQueryItem } from '../types/pageSettings'


### PR DESCRIPTION
## Issue
Closes #

## Implementation details
- [ ] Removed server-only directives since nextjs turbopack now treats them as 'use server'

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- 