### PR TITLE
fix(directus-next): stop depending on stack-ui

### DIFF
--- a/libs/directus/directus-next/package.json
+++ b/libs/directus/directus-next/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@okam/core-lib": "1.17.0",
     "@okam/directus-node": "0.6.2",
-    "@okam/stack-ui": "1.44.0",
     "@okam/logger": "1.1.0",
     "@okam/next-component": "1.3.0",
     "next": "^15.0.0",

--- a/libs/directus/directus-next/src/pageSettings/interface.ts
+++ b/libs/directus/directus-next/src/pageSettings/interface.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { type TypedDocumentNode } from '@graphql-typed-document-node/core'
-import type { Nullable } from '@okam/stack-ui'
 import type { Variables } from 'graphql-request'
 import type { TDirectusRouteConfig } from '../types/directusRouteConfig'
 import type { Fragmentize } from '../types/Fragments'
@@ -35,7 +34,8 @@ export interface TGetPageSettingsProps<
 }
 
 export type TGetPageSettingsReturn<Item extends TPageSettingsQueryItem> = Omit<Item, 'page_settings'> & {
-  page_settings?: Nullable<
-    Exclude<NonNullable<Item>['page_settings'], Fragmentize<TPageSettings, 'PageSettingsFragment'>>
-  >
+  page_settings?:
+    | Exclude<NonNullable<Item>['page_settings'], Fragmentize<TPageSettings, 'PageSettingsFragment'>>
+    | null
+    | undefined
 }

--- a/libs/directus/directus-next/src/types/pageSettings.ts
+++ b/libs/directus/directus-next/src/types/pageSettings.ts
@@ -1,38 +1,49 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import type { Nullable } from '@okam/stack-ui'
 import type { TFiles } from '../files'
 import type { Fragmentize } from './Fragments'
 
 export interface TPageSettingsTranslation {
-  languages_code?: Nullable<{
-    code?: Nullable<string>
-  }>
-  page_settings_id?: Nullable<{
-    belongs_to_collection?: Nullable<string>
-    belongs_to_key?: Nullable<string>
-  }>
-  title?: Nullable<string>
-  slug?: Nullable<string>
-  path?: Nullable<string>
-  meta_description?: Nullable<string>
-  no_follow?: Nullable<boolean>
-  no_index?: Nullable<boolean>
-  og_image?: Nullable<TFiles>
+  languages_code?:
+    | {
+        code?: string | null | undefined
+      }
+    | null
+    | undefined
+  page_settings_id?:
+    | {
+        belongs_to_collection?: string | null | undefined
+        belongs_to_key?: string | null | undefined
+      }
+    | null
+    | undefined
+  title?: string | null | undefined
+  slug?: string | null | undefined
+  path?: string | null | undefined
+  meta_description?: string | null | undefined
+  no_follow?: boolean | null | undefined
+  no_index?: boolean | null | undefined
+  og_image?: TFiles | null | undefined
 }
 
 export interface TPageSettings {
   id: string
-  belongs_to_collection?: Nullable<string>
-  belongs_to_key?: Nullable<string>
+  belongs_to_collection?: string | null | undefined
+  belongs_to_key?: string | null | undefined
   translations?: DeepNullableArray<TPageSettingsTranslation>
-  route?: Nullable<{
-    translations?: DeepNullableArray<{ route?: Nullable<string> }>
-  }>
+  route?:
+    | {
+        translations?: DeepNullableArray<{ route?: string | null | undefined }>
+      }
+    | null
+    | undefined
 }
 
-export type TPageSettingsQueryItem = Nullable<{
-  page_settings?: TPageSettings | Fragmentize<TPageSettings, 'PageSettingsFragment'>
-}>
+export type TPageSettingsQueryItem =
+  | {
+      page_settings?: TPageSettings | Fragmentize<TPageSettings, 'PageSettingsFragment'>
+    }
+  | null
+  | undefined
 
 export type TPageSettingsItemQuery<Item extends TPageSettingsQueryItem, ItemKey extends string> = {
   [Key in ItemKey]?: MaybeArray<Item> | MaybeArray<Fragmentize<Item>>
@@ -40,6 +51,6 @@ export type TPageSettingsItemQuery<Item extends TPageSettingsQueryItem, ItemKey 
   __typename?: 'Query'
 }
 
-export type DeepNullableArray<T> = Nullable<Nullable<T>[]>
+export type DeepNullableArray<T> = (T | null | undefined)[] | null | undefined
 
 export type MaybeArray<T> = T | (T | null | undefined)[] | null | undefined

--- a/libs/directus/directus-next/vite.config.ts
+++ b/libs/directus/directus-next/vite.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
         }
       ],
       // External packages that should not be bundled into your library.
-      external: [...externalDeps, 'next/navigation', 'next/headers', 'next/server', '@okam/directus-node', '@okam/logger', '@okam/core-lib', '@okam/directus-query', '@okam/next-component'],
+      external: [...externalDeps, 'next/navigation', 'next/headers', 'next/server', '@okam/directus-node', '@okam/logger', '@okam/core-lib', '@okam/directus-query', '@okam/next-component', '@okam/stack-ui'],
     },
     ssr: true,
   },


### PR DESCRIPTION
## Issue
Closes #

## Implementation details
- [ ] Stop bundling stack-ui into directus-next

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Removed `@okam/stack-ui` dependency from the directus-next library.

* **Refactor**
  * Updated type definitions to replace Nullable wrapper types with explicit union syntax (type | null | undefined) across page settings interfaces and query types, improving type clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->