### PR TITLE
fix(core-lib): use named imports for React 19 compatibility

### DIFF
--- a/libs/stack/core-lib/src/utils/createContext.tsx
+++ b/libs/stack/core-lib/src/utils/createContext.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import * as React from 'react'
+import { createContext, use } from 'react'
 
 /**
  * A helper to create a Context and Provider with no upfront default value, and
  * without having to check for undefined all the time.
  */
 function createCtx<A extends object | null>() {
-  const ctx = React.createContext<A | undefined>(undefined)
+  const ctx = createContext<A | undefined>(undefined)
   function useCtx() {
-    const c = React.use(ctx)
+    const c = use(ctx)
 
     if (c === undefined) {
       throw new Error('useCtx must be inside a Provider')
@@ -21,9 +21,9 @@ function createCtx<A extends object | null>() {
 }
 
 export function createCtxNullable<A extends object | null>() {
-  const ctx = React.createContext<A | undefined>(undefined)
+  const ctx = createContext<A | undefined>(undefined)
   function useCtx() {
-    const c = React.use(ctx)
+    const c = use(ctx)
 
     if (c === undefined) {
       return {} as A


### PR DESCRIPTION
## Summary
- Changed namespace imports to named imports for `createContext` and `use` from React
- Fixes "createContext is not exported from 'react'" errors when used with Next.js 15 + React 19 production builds

## Problem
Rollup minified `import * as React from 'react'` to `import * as u from "react"`, and Next.js 15's webpack couldn't resolve `u.createContext` during production builds.

## Solution
Changed:
```typescript
import * as React from 'react'
// React.createContext, React.use
```

To:
```typescript
import { createContext, use } from 'react'
// createContext, use
```

## Test plan
- [x] Verified build output shows `import { createContext as s, use as a } from "react"` instead of namespace import
- [ ] Test in consuming app with Next.js 15 production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimizations with no impact to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->