### PR TITLE
fix(stack-ui): prevent infinite loop in MenuSidePanel with React 19

### DIFF
--- a/libs/stack/stack-ui/src/components/Menu/MenuSidePanel.tsx
+++ b/libs/stack/stack-ui/src/components/Menu/MenuSidePanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { TMenuSidePanelProps } from './interface'
+import { useCallback, useRef } from 'react'
 import { useMenu } from '../../providers/Menu'
 import SidePanel from '../SidePanel'
 import InnerContent from './components/InnerContent'
@@ -18,6 +19,19 @@ function MenuSidePanel(props: TMenuSidePanelProps) {
   } = props
   const { closeBtn, tabState, defaultSelectedKey } = useMenu()
 
+  // Use refs to avoid infinite loop: tabState changes when setSelectedKey is called,
+  // which would recreate the callback if tabState were a dependency
+  const tabStateRef = useRef(tabState)
+  const defaultSelectedKeyRef = useRef(defaultSelectedKey)
+  tabStateRef.current = tabState
+  defaultSelectedKeyRef.current = defaultSelectedKey
+
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    if (!isOpen) {
+      tabStateRef.current?.setSelectedKey(defaultSelectedKeyRef.current)
+    }
+  }, [])
+
   return (
     <SidePanel
       themeName={`${themeName}.sidePanel`}
@@ -27,11 +41,7 @@ function MenuSidePanel(props: TMenuSidePanelProps) {
       id={id}
       TransitionAnimation={TransitionAnimation}
       PanelTransition={PanelTransition}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          tabState?.setSelectedKey(defaultSelectedKey)
-        }
-      }}
+      onOpenChange={handleOpenChange}
     >
       <InnerContent id={id} themeName={themeName} tokens={tokens} customTheme={customTheme} {...rest}>
         {children}


### PR DESCRIPTION
## Summary
- Fix infinite re-render loop in `MenuSidePanel` that occurs with React 19 + Next.js 15 on desktop viewports
- Use refs for `tabState` and `defaultSelectedKey` to keep callback reference stable

## Problem
When `MenuSidePanel` renders on desktop (≥1280px), it triggers "Maximum update depth exceeded" errors:

1. `onOpenChange` callback calls `tabState.setSelectedKey()`
2. This mutates `tabState`, which was a `useCallback` dependency
3. New callback reference triggers `SidePanel`'s `useEffect`
4. Effect calls `onOpenChange` again → infinite loop

## Solution
Use refs to read the latest values without adding them as dependencies:

```typescript
const tabStateRef = useRef(tabState)
const defaultSelectedKeyRef = useRef(defaultSelectedKey)
tabStateRef.current = tabState
defaultSelectedKeyRef.current = defaultSelectedKey

const handleOpenChange = useCallback((isOpen: boolean) => {
  if (!isOpen) {
    tabStateRef.current?.setSelectedKey(defaultSelectedKeyRef.current)
  }
}, [])
```

## Test plan
- [x] Tested with vanier-mono Next.js 15 + React 19 app
- [x] Verified no "Maximum update depth exceeded" errors on desktop
- [x] Verified search input renders correctly on the search page
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the side panel menu would retain its previously selected tab when closed and reopened. The menu now correctly resets to its default selection state upon reopening.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->