### PR TITLE
fix(next-component): anchor href support

### DIFF
--- a/libs/stack/next-component/src/components/Link/link.stories.tsx
+++ b/libs/stack/next-component/src/components/Link/link.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { Box, Typography } from '@okam/stack-ui'
 import { I18nProvider } from 'react-aria'
 import Link from './index'
@@ -25,7 +25,9 @@ const meta: Meta<typeof Link> = {
   decorators: [
     Story => (
       <I18nProvider locale="en">
-        <Story />
+        <Box customTheme="flex flex-col gap-4">
+          <Story />
+        </Box>
       </I18nProvider>
     ),
   ],
@@ -144,7 +146,7 @@ const meta: Meta<typeof Link> = {
     },
   },
   render: ({ href, ...args }) => (
-    <Box customTheme="flex flex-col gap-4">
+    <>
       <Box customTheme="w-fit">
         <Link href={href} {...args} />
       </Box>
@@ -154,7 +156,7 @@ const meta: Meta<typeof Link> = {
           {href.toString()}
         </Typography>
       </Box>
-    </Box>
+    </>
   ),
 }
 
@@ -210,5 +212,12 @@ export const ContextLocale: Story = {
   args: {
     href: '/products/2',
     locale: undefined,
+  },
+}
+
+export const Anchor: Story = {
+  args: {
+    href: '#products-2',
+    as: 'a',
   },
 }

--- a/libs/stack/next-component/src/hooks/useLink/index.ts
+++ b/libs/stack/next-component/src/hooks/useLink/index.ts
@@ -40,8 +40,9 @@ export function useLinkLocale(props: TLink) {
 export function localizeHref(href: LinkProps['href'], locale: LinkProps['locale']): string {
   const hrefString = href.toString()
 
+  const isAnchor = hrefString.startsWith('#')
   const isExternal = /^[a-z]+:\/\//i.test(hrefString) || hrefString.startsWith('//')
-  if (isExternal)
+  if (isExternal || isAnchor)
     return hrefString
 
   if (locale != null && locale !== false) {


### PR DESCRIPTION
## Issue
Closes #411

## Implementation details
- [x] link with anchor `href` don't localize their href anymore

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- `npx nx run next-component:storybook`
- Check "Anchor" link story
- Link href should not be prefixed by locale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anchor link handling to ensure in-page navigation links work correctly without locale prefixing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->