### PR TITLE
chore(release): stack-ui v2.0.3

### DIFF
--- a/libs/directus/directus-block/package.json
+++ b/libs/directus/directus-block/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
     "@okam/directus-query": "2.0.0",
-    "@okam/stack-ui": "2.0.2",
+    "@okam/stack-ui": "2.0.3",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.2",
     "radashi": "^12.3.0"

--- a/libs/directus/directus-flexible-content/package.json
+++ b/libs/directus/directus-flexible-content/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@okam/directus-block": "2.0.1",
-    "@okam/stack-ui": "2.0.2",
+    "@okam/stack-ui": "2.0.3",
     "@tiptap/core": "^3.15.3",
     "@tiptap/extension-subscript": "^3.15.3",
     "@tiptap/extension-superscript": "^3.15.3",

--- a/libs/directus/directus-next-component/package.json
+++ b/libs/directus/directus-next-component/package.json
@@ -43,7 +43,7 @@
     "@okam/directus-next": "2.0.1",
     "@okam/logger": "1.1.0",
     "@okam/next-component": "2.0.2",
-    "@okam/stack-ui": "2.0.2",
+    "@okam/stack-ui": "2.0.3",
     "@react-spring/web": "^10.0.3",
     "next": "^15.1.0 || ^16.0.0",
     "radashi": "^12.3.0",

--- a/libs/stack/next-component/package.json
+++ b/libs/stack/next-component/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@okam/react-utils": "0.0.1",
-    "@okam/stack-ui": "2.0.2",
+    "@okam/stack-ui": "2.0.3",
     "next": "^15.1.0 || ^16.0.0",
     "nuqs": "^2.4.3",
     "radashi": "^12.3.0",

--- a/libs/stack/stack-ui/CHANGELOG.md
+++ b/libs/stack/stack-ui/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 2.0.3 (2026-03-11)
+
+### 🩹 Fixes
+
+- resolve high-severity dependabot alerts ([#429](https://github.com/OKAMca/stack/pull/429))
+- **stack-ui:** error message and validation fixes ([6e4d9f21](https://github.com/OKAMca/stack/commit/6e4d9f21))
+- **stack-ui:** validation fix ([fc54df32](https://github.com/OKAMca/stack/commit/fc54df32))
+- **stack-ui:** selection change fixes ([89bf4c0e](https://github.com/OKAMca/stack/commit/89bf4c0e))
+- **stack-ui:** controlled state fix ([431d9b63](https://github.com/OKAMca/stack/commit/431d9b63))
+- **stack-ui:** remove state from typing ([e3bbfc49](https://github.com/OKAMca/stack/commit/e3bbfc49))
+- **stack-ui:** listbox clear all fix ([0fb6428a](https://github.com/OKAMca/stack/commit/0fb6428a))
+- **stack-ui:** revert select change ([f884b2fa](https://github.com/OKAMca/stack/commit/f884b2fa))
+- **stack-ui:** revert debounce delay, modal fixes ([b8422eb4](https://github.com/OKAMca/stack/commit/b8422eb4))
+- **stack-ui:** add cursor-pointer ([cfce38fb](https://github.com/OKAMca/stack/commit/cfce38fb))
+- **stack-ui:** combobox migration fixes ([69a02a6c](https://github.com/OKAMca/stack/commit/69a02a6c))
+
+### ❤️ Thank You
+
+- Marie-Maxime Tanguay @marie-maxime
+- Max Hilland
+
 ## 2.0.2 (2026-02-27)
 
 This was a version bump only for stack-ui to align it with other projects, there were no code changes.

--- a/libs/stack/stack-ui/package.json
+++ b/libs/stack/stack-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/stack-ui",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },


### PR DESCRIPTION
## Summary
- Release stack-ui v2.0.3 (patch)
- Bumps dependent packages: next-component, directus-next, directus-block, directus-next-component, directus-flexible-content

Generated by `nx release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Addressed high-severity security vulnerabilities affecting components.
  * Improved validation logic and enhanced state management reliability.

* **Updates**
  * Updated component library and related dependencies to version 2.0.3 with important security fixes and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->