### PR TITLE
chore(release): update pnpm-lock.yaml for stack-ui v2.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,7 +383,7 @@ importers:
         specifier: 2.0.0
         version: link:../directus-query
       '@okam/stack-ui':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../../stack/stack-ui
       graphql:
         specifier: ^16.9.0
@@ -405,7 +405,7 @@ importers:
         specifier: 2.0.1
         version: link:../directus-block
       '@okam/stack-ui':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../../stack/stack-ui
       '@tiptap/core':
         specifier: ^3.15.3
@@ -487,7 +487,7 @@ importers:
         specifier: 2.0.2
         version: link:../../stack/next-component
       '@okam/stack-ui':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../../stack/stack-ui
       '@react-spring/web':
         specifier: ^10.0.3
@@ -566,7 +566,7 @@ importers:
         specifier: 0.0.1
         version: link:../react-utils
       '@okam/stack-ui':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../stack-ui
       '@react-stately/selection':
         specifier: ^3.20.0


### PR DESCRIPTION
## Summary
- Updates pnpm-lock.yaml to reflect stack-ui v2.0.3 version bump across workspace packages