### PR TITLE
chore(release): bump package versions to align with stack-ui 2.0.3

### DIFF
--- a/libs/directus/directus-block/CHANGELOG.md
+++ b/libs/directus/directus-block/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.2 (2026-03-17)
+
+### 🩹 Fixes
+
+- resolve high-severity dependabot alerts ([#429](https://github.com/OKAMca/stack/pull/429))
+
+### ❤️ Thank You
+
+- Marie-Maxime Tanguay @marie-maxime
+
 ## 2.0.1 (2026-02-27)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-block/package.json
+++ b/libs/directus/directus-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-block",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },

--- a/libs/directus/directus-flexible-content/CHANGELOG.md
+++ b/libs/directus/directus-flexible-content/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2 (2026-03-17)
+
+### 🧱 Updated Dependencies
+
+- Updated directus-block to 2.0.2
+
 ## 2.0.1 (2026-02-27)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-flexible-content/package.json
+++ b/libs/directus/directus-flexible-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-flexible-content",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -29,7 +29,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@okam/directus-block": "2.0.1",
+    "@okam/directus-block": "2.0.2",
     "@okam/stack-ui": "2.0.3",
     "@tiptap/core": "^3.15.3",
     "@tiptap/extension-subscript": "^3.15.3",

--- a/libs/directus/directus-next-component/CHANGELOG.md
+++ b/libs/directus/directus-next-component/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2 (2026-03-17)
+
+### 🧱 Updated Dependencies
+
+- Updated next-component to 2.0.3
+- Updated directus-next to 2.0.2
+
 ## 2.0.1 (2026-02-27)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-next-component/package.json
+++ b/libs/directus/directus-next-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next-component",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -40,9 +40,9 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@okam/directus-next": "2.0.1",
+    "@okam/directus-next": "2.0.2",
     "@okam/logger": "1.1.0",
-    "@okam/next-component": "2.0.2",
+    "@okam/next-component": "2.0.3",
     "@okam/stack-ui": "2.0.3",
     "@react-spring/web": "^10.0.3",
     "next": "^15.1.0 || ^16.0.0",

--- a/libs/directus/directus-next/CHANGELOG.md
+++ b/libs/directus/directus-next/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2 (2026-03-17)
+
+### 🧱 Updated Dependencies
+
+- Updated next-component to 2.0.3
+
 ## 1.2.30 (2026-02-20)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-next/package.json
+++ b/libs/directus/directus-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -46,7 +46,7 @@
     "@okam/directus-node": "1.0.0",
     "@okam/directus-query": "2.0.0",
     "@okam/logger": "1.1.0",
-    "@okam/next-component": "2.0.2",
+    "@okam/next-component": "2.0.3",
     "graphql-request": "^7.1.2",
     "next": "^15.1.0 || ^16.0.0",
     "radashi": "^12.3.0",

--- a/libs/stack/next-component/CHANGELOG.md
+++ b/libs/stack/next-component/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.3 (2026-03-17)
+
+### 🩹 Fixes
+
+- resolve high-severity dependabot alerts ([#429](https://github.com/OKAMca/stack/pull/429))
+
+### ❤️ Thank You
+
+- Marie-Maxime Tanguay @marie-maxime
+
 ## 2.0.2 (2026-02-27)
 
 ### 🧱 Updated Dependencies

--- a/libs/stack/next-component/package.json
+++ b/libs/stack/next-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/next-component",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,7 +402,7 @@ importers:
   libs/directus/directus-flexible-content:
     dependencies:
       '@okam/directus-block':
-        specifier: 2.0.1
+        specifier: 2.0.2
         version: link:../directus-block
       '@okam/stack-ui':
         specifier: 2.0.3
@@ -457,7 +457,7 @@ importers:
         specifier: 1.1.0
         version: link:../../stack/logger
       '@okam/next-component':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../../stack/next-component
       graphql-request:
         specifier: ^7.1.2
@@ -478,13 +478,13 @@ importers:
   libs/directus/directus-next-component:
     dependencies:
       '@okam/directus-next':
-        specifier: 2.0.1
+        specifier: 2.0.2
         version: link:../directus-next
       '@okam/logger':
         specifier: 1.1.0
         version: link:../../stack/logger
       '@okam/next-component':
-        specifier: 2.0.2
+        specifier: 2.0.3
         version: link:../../stack/next-component
       '@okam/stack-ui':
         specifier: 2.0.3


### PR DESCRIPTION
## Summary

- Bumps `@okam/next-component` to `2.0.3` (missing publish after stack-ui 2.0.3 dep update)
- Bumps `@okam/directus-next`, `@okam/directus-block`, `@okam/directus-next-component`, `@okam/directus-flexible-content` to `2.0.2`
- Updates all cross-package dependency references to new versions
- Adds missing release tags that were skipped during previous publishes

## Context

The last publish workflow skipped these packages because their versions were already on npm, but the internal `@okam/stack-ui` dep had been bumped to `2.0.3` without a version bump. This caused consumers to get two versions of `@okam/stack-ui` installed simultaneously, breaking styling.

## Test plan

- [ ] Merge PR
- [ ] Trigger publish workflow manually
- [ ] Verify all 5 packages are published to npm at their new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved high-severity security vulnerabilities identified by automated security scanning across the package ecosystem.

* **Chores**
  * Released coordinated version updates across multiple interconnected packages to ensure compatibility and stability.
  * Updated internal dependencies to incorporate security improvements and maintain system integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->