### PR TITLE
chore(release): directus-next v2.2.2, directus-block v2.1.2

### DIFF
--- a/libs/directus/directus-block/CHANGELOG.md
+++ b/libs/directus/directus-block/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.2 (2026-04-14)
+
+### 🩹 Fixes
+
+- **directus-block:** BlockDispatcher is a synchronous function ([#477](https://github.com/OKAMca/stack/pull/477))
+
+### ❤️ Thank You
+
+- Pierre-Olivier Clerson @poclerson
+
 ## 2.1.0 (2026-04-06)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-block/package.json
+++ b/libs/directus/directus-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-block",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },

--- a/libs/directus/directus-flexible-content/CHANGELOG.md
+++ b/libs/directus/directus-flexible-content/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.2 (2026-04-14)
+
+### 🧱 Updated Dependencies
+
+- Updated directus-block to 2.1.2
+
 ## 2.1.0 (2026-04-06)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-flexible-content/package.json
+++ b/libs/directus/directus-flexible-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-flexible-content",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -29,7 +29,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@okam/directus-block": "2.1.1",
+    "@okam/directus-block": "2.1.2",
     "@okam/stack-ui": "2.1.1",
     "@tiptap/core": "^3.15.3",
     "@tiptap/extension-subscript": "^3.15.3",

--- a/libs/directus/directus-next-component/CHANGELOG.md
+++ b/libs/directus/directus-next-component/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.3 (2026-04-14)
+
+### 🧱 Updated Dependencies
+
+- Updated directus-next to 2.2.2
+
 ## 2.1.2 (2026-04-09)
 
 ### 🩹 Fixes

--- a/libs/directus/directus-next-component/package.json
+++ b/libs/directus/directus-next-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next-component",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -40,7 +40,7 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@okam/directus-next": "2.2.1",
+    "@okam/directus-next": "2.2.2",
     "@okam/logger": "1.1.0",
     "@okam/next-component": "2.1.1",
     "@okam/stack-ui": "2.1.1",

--- a/libs/directus/directus-next/CHANGELOG.md
+++ b/libs/directus/directus-next/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.2 (2026-04-14)
+
+### 🩹 Fixes
+
+- issue with setvar not correctly being applied preventing cache ([#480](https://github.com/OKAMca/stack/pull/480))
+
+### ❤️ Thank You
+
+- Marie-Maxime Tanguay @marie-maxime
+
 ## 2.2.0 (2026-04-06)
 
 ### 🚀 Features

--- a/libs/directus/directus-next/package.json
+++ b/libs/directus/directus-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,7 +408,7 @@ importers:
   libs/directus/directus-flexible-content:
     dependencies:
       '@okam/directus-block':
-        specifier: 2.1.1
+        specifier: 2.1.2
         version: link:../directus-block
       '@okam/stack-ui':
         specifier: 2.1.1
@@ -484,7 +484,7 @@ importers:
   libs/directus/directus-next-component:
     dependencies:
       '@okam/directus-next':
-        specifier: 2.2.1
+        specifier: 2.2.2
         version: link:../directus-next
       '@okam/logger':
         specifier: 1.1.0


### PR DESCRIPTION
## Summary
- **directus-next** 2.2.1 → 2.2.2: fix setvar not correctly being applied preventing cache (#480)
- **directus-block** 2.1.1 → 2.1.2: fix BlockDispatcher is a synchronous function (#477)
- **directus-next-component** 2.1.2 → 2.1.3: dependency bump (directus-next)
- **directus-flexible-content** 2.1.1 → 2.1.2: dependency bump (directus-block)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass