### PR TITLE
fix: typo

### DIFF
--- a/libs/stack/next-component/src/hooks/useLink/interface.ts
+++ b/libs/stack/next-component/src/hooks/useLink/interface.ts
@@ -63,7 +63,7 @@ export type TLinkI18nConfig
     localePrefix?: `${LocalePrefix.Always}` | undefined
   })
 
-export interface TLink extends Omit<NextLinkProps, 'scroll' | 'as' | 'hre'> {
+export interface TLink extends Omit<NextLinkProps, 'scroll' | 'as' | 'href'> {
   href: string | UrlObject
   /**
    * @default true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect type definition that was preventing proper property inheritance handling in the link component interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->