### PR TITLE
chore(release): next-component v2.1.2

### DIFF
--- a/libs/directus/directus-next-component/CHANGELOG.md
+++ b/libs/directus/directus-next-component/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.4 (2026-04-15)
+
+### 🧱 Updated Dependencies
+
+- Updated next-component to 2.1.2
+- Updated directus-next to 2.2.3
+
 ## 2.1.3 (2026-04-14)
 
 ### 🧱 Updated Dependencies

--- a/libs/directus/directus-next-component/package.json
+++ b/libs/directus/directus-next-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next-component",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -40,9 +40,9 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@okam/directus-next": "2.2.2",
+    "@okam/directus-next": "2.2.3",
     "@okam/logger": "1.1.0",
-    "@okam/next-component": "2.1.1",
+    "@okam/next-component": "2.1.2",
     "@okam/stack-ui": "2.1.1",
     "@react-spring/web": "^10.0.3",
     "radashi": "^12.3.0",

--- a/libs/directus/directus-next/CHANGELOG.md
+++ b/libs/directus/directus-next/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.3 (2026-04-15)
+
+### 🧱 Updated Dependencies
+
+- Updated next-component to 2.1.2
+
 ## 2.2.2 (2026-04-14)
 
 ### 🩹 Fixes

--- a/libs/directus/directus-next/package.json
+++ b/libs/directus/directus-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/directus-next",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },
@@ -46,7 +46,7 @@
     "@okam/directus-node": "1.2.0",
     "@okam/directus-query": "2.1.1",
     "@okam/logger": "1.1.0",
-    "@okam/next-component": "2.1.1",
+    "@okam/next-component": "2.1.2",
     "graphql-request": "^7.1.2",
     "radashi": "^12.3.0",
     "server-only": "0.0.1",

--- a/libs/stack/next-component/CHANGELOG.md
+++ b/libs/stack/next-component/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.2 (2026-04-15)
+
+### 🩹 Fixes
+
+- typo ([#483](https://github.com/OKAMca/stack/pull/483))
+
+### ❤️ Thank You
+
+- Marie-Maxime Tanguay @marie-maxime
+
 ## 2.1.0 (2026-03-26)
 
 ### 🚀 Features

--- a/libs/stack/next-component/package.json
+++ b/libs/stack/next-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okam/next-component",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "repository": {
     "url": "https://github.com/OKAMca/stack.git"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,7 +463,7 @@ importers:
         specifier: 1.1.0
         version: link:../../stack/logger
       '@okam/next-component':
-        specifier: 2.1.1
+        specifier: 2.1.2
         version: link:../../stack/next-component
       graphql-request:
         specifier: ^7.1.2
@@ -484,13 +484,13 @@ importers:
   libs/directus/directus-next-component:
     dependencies:
       '@okam/directus-next':
-        specifier: 2.2.2
+        specifier: 2.2.3
         version: link:../directus-next
       '@okam/logger':
         specifier: 1.1.0
         version: link:../../stack/logger
       '@okam/next-component':
-        specifier: 2.1.1
+        specifier: 2.1.2
         version: link:../../stack/next-component
       '@okam/stack-ui':
         specifier: 2.1.1


### PR DESCRIPTION
## Summary
- **next-component** 2.1.1 → 2.1.2: fix typo in useLink interface (#483)
- **directus-next** 2.2.2 → 2.2.3: dependency bump (next-component)
- **directus-next-component** 2.1.3 → 2.1.4: dependency bump (next-component, directus-next)

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass