### PR TITLE
fix(next-component): useLink applies trailing slash at the end of pathname

### DIFF
--- a/libs/stack/next-component/src/components/Link/link.stories.tsx
+++ b/libs/stack/next-component/src/components/Link/link.stories.tsx
@@ -214,6 +214,18 @@ export const Anchor: Story = {
   },
 }
 
+export const WithAnchor: Story = {
+  args: {
+    href: '/products/2#details',
+  },
+}
+
+export const WithSearchParams: Story = {
+  args: {
+    href: '/products/2?ref=homepage',
+  },
+}
+
 export const LocalePrefixAlways: Story = {
   args: {
     href: '/products/2',

--- a/libs/stack/next-component/src/hooks/useLink/index.ts
+++ b/libs/stack/next-component/src/hooks/useLink/index.ts
@@ -12,6 +12,7 @@ import { LocalePrefix } from './interface'
 type Params = Record<string, string | string[] | undefined>
 
 const EXTERNAL_URL_RE = /^[a-z]+:\/\//i
+const DUMMY_BASE = 'http://x'
 
 function scrollToTop(behavior: ScrollBehavior) {
   window?.scrollTo?.({ top: 0, behavior })
@@ -22,6 +23,36 @@ function getParamsLocale(params: Params | undefined): string | undefined {
   if (Array.isArray(locale))
     return locale[0]
   return locale
+}
+
+/**
+ * Ensures the pathname portion of a URL ends with a trailing slash,
+ * preserving any search params and hash.
+ */
+function addTrailingSlashToPathname(hrefString: string): string {
+  const isProtocolRelative = hrefString.startsWith('//')
+  const isExternal = EXTERNAL_URL_RE.test(hrefString)
+
+  try {
+    const url = new URL(
+      isProtocolRelative ? `http:${hrefString}` : hrefString,
+      DUMMY_BASE,
+    )
+
+    if (!url.pathname.endsWith('/'))
+      url.pathname += '/'
+
+    if (isExternal)
+      return url.toString()
+
+    if (isProtocolRelative)
+      return `//${url.host}${url.pathname}${url.search}${url.hash}`
+
+    return `${url.pathname}${url.search}${url.hash}`
+  }
+  catch {
+    return hrefString.endsWith('/') ? hrefString : `${hrefString}/`
+  }
 }
 
 /**
@@ -51,19 +82,18 @@ export function useLinkLocale(props: TLink) {
 
 export function localizeHref(href: LinkProps['href'], locale: LinkProps['locale']): string {
   const hrefString = href.toString()
-  const hasTrailingSlash = hrefString.endsWith('/')
 
   const isAnchor = hrefString.startsWith('#')
-  const isExternal = EXTERNAL_URL_RE.test(hrefString) || hrefString.startsWith('//')
-  let finalHref: string
-  if (locale != null && locale !== false && !isExternal && !isAnchor) {
-    finalHref = `/${locale}${hrefString}`
-  }
-  else {
-    finalHref = hrefString
-  }
+  if (isAnchor)
+    return hrefString
 
-  return (hasTrailingSlash || isAnchor) ? finalHref : `${finalHref}/`
+  const isExternal = EXTERNAL_URL_RE.test(hrefString) || hrefString.startsWith('//')
+
+  const withLocale = (locale != null && locale !== false && !isExternal)
+    ? `/${locale}${hrefString}`
+    : hrefString
+
+  return addTrailingSlashToPathname(withLocale)
 }
 
 /**


### PR DESCRIPTION
## Issue
Closes #485

## Implementation details
- [x] useLink takes search params/anchor into account while applying trailing slash at the end of pathname

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- next-component storybook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Storybook stories demonstrating Link component handling of hash fragments and query parameters.

* **Refactor**
  * Improved URL normalization logic to ensure proper pathname formatting while preserving search parameters and hash anchors across localized and external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->