### PR TITLE
fix: forward ref to React Hook Form for autofocus on select field

### DIFF
--- a/libs/stack/stack-ui/src/components/fields/Select/Select.stories.jsx
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.stories.jsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form'
-import { Select, ReactHookFormSelect } from './Select'
+import { ReactHookFormSelect, Select } from './Select'
 
 export default {
   title: 'Form/Fields/Select',
@@ -93,7 +93,7 @@ export const MixedContent = {
   },
 }
 
-const ReactHookFormAutofocusTemplate = () => {
+function ReactHookFormAutofocusTemplate() {
   const methods = useForm({ mode: 'onTouched', defaultValues: { testSelect: null } })
 
   return (

--- a/libs/stack/stack-ui/src/components/fields/Select/Select.stories.jsx
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.stories.jsx
@@ -1,4 +1,5 @@
-import { Select } from './Select'
+import { FormProvider, useForm } from 'react-hook-form'
+import { Select, ReactHookFormSelect } from './Select'
 
 export default {
   title: 'Form/Fields/Select',
@@ -90,4 +91,37 @@ export const MixedContent = {
       { key: '6', value: 'Option 6' },
     ],
   },
+}
+
+const ReactHookFormAutofocusTemplate = () => {
+  const methods = useForm({ mode: 'onTouched', defaultValues: { testSelect: null } })
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(() => {})} style={{ maxWidth: '300px' }}>
+        <p style={{ fontSize: '12px', color: '#666', marginBottom: '12px' }}>
+          Submit without selecting to test autofocus on validation error
+        </p>
+        <ReactHookFormSelect
+          name="testSelect"
+          label="Season (Required)"
+          options={defaultOptions}
+          placeholderLabel="Select a season"
+          rules={{ required: true }}
+          required
+        />
+        <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+          <button type="submit">Submit</button>
+          <button type="button" onClick={() => methods.reset({ testSelect: null })}>
+            Reset
+          </button>
+        </div>
+      </form>
+    </FormProvider>
+  )
+}
+
+export const ReactHookFormAutofocus = {
+  render: ReactHookFormAutofocusTemplate,
+  name: 'React Hook Form Autofocus',
 }

--- a/libs/stack/stack-ui/src/components/fields/Select/Select.tsx
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { CSSProperties, RefObject } from 'react'
+import type { CSSProperties } from 'react'
 import type { RegisterOptions } from 'react-hook-form'
 import type { TToken } from '../../../providers/Theme/interface'
 import type { TSelectProps } from './Select.interface'
@@ -41,15 +41,7 @@ export function Select<T extends TToken>(props: TSelectProps<T>) {
     ...rest
   } = props
 
-  const inputRef = useRef<HTMLElement>(null)
   const buttonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null)
-
-  const mergeRefs = (ref: HTMLElement | null) => {
-    if (ref != null) {
-      hookFormRef?.(ref)
-      inputRef.current = ref
-    }
-  }
 
   const filteredOptions = options?.filter(option => !(option.key?.includes('header-') ?? false))
 
@@ -68,7 +60,7 @@ export function Select<T extends TToken>(props: TSelectProps<T>) {
   const { triggerProps, menuProps, labelProps, valueProps } = useSelect(
     { ...rest, label, isDisabled: disabled, isRequired: required, isInvalid },
     state,
-    mergeRefs as unknown as RefObject<HTMLElement | null>,
+    buttonRef,
   )
 
   const { onPress, onPressStart, ...restofTriggerProps } = triggerProps
@@ -88,7 +80,10 @@ export function Select<T extends TToken>(props: TSelectProps<T>) {
             onPress?.(event)
             onPressStart?.(event)
           }}
-          ref={buttonRef}
+          ref={(el) => {
+            buttonRef.current = el as HTMLButtonElement & HTMLAnchorElement
+            hookFormRef?.(el as any)
+          }}
           disabled={disabled}
           themeName={`${themeName}.button`}
           tokens={{ ...tokens, intent: isError ? 'error' : 'default' }}

--- a/libs/stack/stack-ui/src/components/fields/Select/Select.tsx
+++ b/libs/stack/stack-ui/src/components/fields/Select/Select.tsx
@@ -82,7 +82,9 @@ export function Select<T extends TToken>(props: TSelectProps<T>) {
           }}
           ref={(el) => {
             buttonRef.current = el as HTMLButtonElement & HTMLAnchorElement
-            hookFormRef?.(el as any)
+            if (el != null) {
+              hookFormRef?.(el)
+            }
           }}
           disabled={disabled}
           themeName={`${themeName}.button`}


### PR DESCRIPTION
## Issue Link

## Implementation details
- [ ] Fix the select field so that it can be focused on error state.

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- I used my local stack-ui in the bellmediamono project.
- On the lede, test the register form. When you click the submit button, it will select the first field with an error.
- This didn't work before for the select, but now it does.
