### PR TITLE
fix: inert tag on slides

### DIFF
--- a/libs/stack/stack-ui/src/components/Carousel/swiper/CarouselSwiper.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/swiper/CarouselSwiper.tsx
@@ -22,9 +22,9 @@ function CarouselSwiper(props: TCarouselSwiperProps) {
   return (
     <Swiper {...rest} className={swiperTheme} wrapperClass={swiperWrapperTheme} ref={ref}>
       {typeof children === 'function'
-        ? slides.map(slide => (
+        ? slides.map((slide, index) => (
             <SwiperSlide key={`slide-${slide.id}`} className={slideTheme}>
-              {children({ themeName: `${themeName}.slide`, tokens, ...slide })}
+              {children({ themeName: `${themeName}.slide`, tokens, swiperSlideIndex: index, ...slide })}
             </SwiperSlide>
           ))
         : children}

--- a/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSlide.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSlide.tsx
@@ -1,21 +1,10 @@
 'use client'
 
-import type { RefObject } from 'react'
-import type { Swiper } from 'swiper/types'
 import type { TCarouselSlide, TCarouselSlideProps } from './interface'
 import { isEmpty } from 'radashi'
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 import { mergeProps } from 'react-aria'
-
-function getClasses(swiper: Swiper | undefined, ref: RefObject<HTMLElement | null>) {
-  if (ref.current == null || swiper == null)
-    return []
-  const { slideClass = 'swiper-slide' } = swiper.params
-  const classes = ref.current?.className.split(' ').filter((className) => {
-    return className.indexOf('swiper-slide') === 0 || className.indexOf(slideClass) === 0
-  })
-  return classes
-}
+import { useCarousel } from '../../../providers/Carousel'
 
 export function useCarouselSlide(props: TCarouselSlideProps): TCarouselSlide {
   const {
@@ -31,18 +20,14 @@ export function useCarouselSlide(props: TCarouselSlideProps): TCarouselSlide {
   const a11yParams = typeof swiper?.params?.a11y === 'object' ? swiper.params.a11y : undefined
   const { itemRoleDescriptionMessage = 'slide', slideRole = 'group' } = a11yParams ?? {}
   const hasTitle = !isEmpty(title)
+  const { activeIndex, controller } = useCarousel() ?? {}
+  const slidesPerView = typeof controller?.params?.slidesPerView === 'number' ? controller.params.slidesPerView : 1
   const ref = useRef<HTMLElement>(null)
 
-  const swiperSlide = useMemo(() => {
-    const classes = getClasses(swiper, ref)
-    return {
-      isActive: classes?.includes('swiper-slide-active'),
-      isVisible: classes?.includes('swiper-slide-visible'),
-      isPrev: classes?.includes('swiper-slide-prev'),
-      isNext: classes?.includes('swiper-slide-next'),
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref.current triggers recalc when DOM element attaches; ref object is stable
-  }, [ref.current])
+  const isActive = swiperSlideIndex === activeIndex
+  const isVisible = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex >= activeIndex && swiperSlideIndex < activeIndex + slidesPerView
+  const isPrev = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex === activeIndex - 1
+  const isNext = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex === activeIndex + slidesPerView
 
   return {
     ref,
@@ -50,9 +35,12 @@ export function useCarouselSlide(props: TCarouselSlideProps): TCarouselSlide {
       ...(hasTitle ? { 'aria-labelledby': id } : { 'aria-label': legacyAriaLabel ?? ariaLabel }),
       'aria-roledescription': itemRoleDescriptionMessage ?? undefined,
       'role': slideRole,
-      'inert': `!${swiperSlide.isVisible}`,
+      'inert': !isVisible,
     }),
     titleProps: {},
-    ...swiperSlide,
+    isActive,
+    isVisible,
+    isPrev,
+    isNext,
   }
 }

--- a/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSlide.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSlide.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { TCarouselSlide, TCarouselSlideProps } from './interface'
-import { isEmpty } from 'radashi'
+import { isEmpty, isNullish } from 'radashi'
 import { useRef } from 'react'
 import { mergeProps } from 'react-aria'
 import { useCarousel } from '../../../providers/Carousel'
@@ -20,14 +20,15 @@ export function useCarouselSlide(props: TCarouselSlideProps): TCarouselSlide {
   const a11yParams = typeof swiper?.params?.a11y === 'object' ? swiper.params.a11y : undefined
   const { itemRoleDescriptionMessage = 'slide', slideRole = 'group' } = a11yParams ?? {}
   const hasTitle = !isEmpty(title)
-  const { activeIndex, controller } = useCarousel() ?? {}
+  const { activeIndex, controller } = useCarousel()
   const slidesPerView = typeof controller?.params?.slidesPerView === 'number' ? controller.params.slidesPerView : 1
   const ref = useRef<HTMLElement>(null)
 
+  const hasIndex = !isNullish(swiperSlideIndex)
   const isActive = swiperSlideIndex === activeIndex
-  const isVisible = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex >= activeIndex && swiperSlideIndex < activeIndex + slidesPerView
-  const isPrev = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex === activeIndex - 1
-  const isNext = swiperSlideIndex != null && activeIndex != null && swiperSlideIndex === activeIndex + slidesPerView
+  const isVisible = hasIndex && swiperSlideIndex >= activeIndex && swiperSlideIndex < activeIndex + slidesPerView
+  const isPrev = hasIndex && swiperSlideIndex === activeIndex - 1
+  const isNext = hasIndex && swiperSlideIndex === activeIndex + slidesPerView
 
   return {
     ref,

--- a/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSwiper.ts
+++ b/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSwiper.ts
@@ -45,7 +45,7 @@ export function useCarouselSwiper(props: TCarouselSwiperProps): TCarouselSwiper 
     'role': 'group',
     'onSwiper': setController,
     'onSlideChange': (swiper) => {
-      setActiveIndex(swiper.activeIndex)
+      setActiveIndex(swiper.realIndex)
     },
     'modules': importedModules,
     'keyboard': {


### PR DESCRIPTION
## Issue Link

## Implementation details
- [ ] Visible slides do not have the inert tag

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Check the storybook for the carousel and check the html to see that only the non-visible slides have the inert property


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Carousel now determines slide visibility, active/previous/next state and navigation positioning from shared carousel context rather than DOM cues, improving consistency across interactions.
* **New Features / Bug Fixes**
  * When using a render-function as carousel children, the argument now includes the current slide position.
  * Slide change reporting now reflects the swiper’s real index for correct navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->