### PR TITLE
Fix(stack UI) carousel navigation

### DIFF
--- a/libs/stack/stack-ui/src/components/Carousel/carousel.mdx
+++ b/libs/stack/stack-ui/src/components/Carousel/carousel.mdx
@@ -66,6 +66,18 @@ import 'swiper/css/keyboard'
   <Story />
 </Canvas>
 
+### Navigation with pagination bullets
+
+<Canvas of={CarouselStories.NavigationWithPaginationBullets}>
+  <Story />
+</Canvas>
+
+### Navigation with pagination bullets (looping)
+
+<Canvas of={CarouselStories.NavigationWithPaginationBulletsLooping}>
+  <Story />
+</Canvas>
+
 ### Pagination Fraction
 
 <Canvas of={CarouselStories.PaginationFraction}>

--- a/libs/stack/stack-ui/src/components/Carousel/carousel.stories.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/carousel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import type { ComponentProps, ComponentType } from 'react'
 import Carousel from '.'
 import { Icon, Typography } from '../..'
+import LegacyCarousel from './components/LegacyCarousel'
 import CarouselNextNavigation from './navigation/CarouselNextNavigation'
 import CarouselPrevNavigation from './navigation/CarouselPrevNavigation'
 import CarouselPagination from './pagination/CarouselPagination'
@@ -14,6 +15,7 @@ import 'swiper/css/pagination'
 import 'swiper/css/autoplay'
 
 type CarouselArgs = ComponentProps<typeof Carousel>
+type LegacyCarouselArgs = ComponentProps<typeof LegacyCarousel>
 
 const meta: Meta<typeof Carousel> = {
   title: 'Base Components/Carousel',
@@ -72,6 +74,22 @@ const meta: Meta<typeof Carousel> = {
         title: 'Slide 4 title',
         children: <Typography>Slide 4</Typography>,
       },
+      {
+        id: '5',
+        children: <Typography>Slide 5</Typography>,
+      },
+      {
+        id: '6',
+        children: <Typography>Slide 6</Typography>,
+      },
+      {
+        id: '7',
+        children: <Typography>Slide 7</Typography>,
+      },
+      {
+        id: '8',
+        children: <Typography>Slide 8</Typography>,
+      },
     ],
     onSwiper: () => {
       console.log('Swiper initialized')
@@ -80,22 +98,36 @@ const meta: Meta<typeof Carousel> = {
       console.log('Slide changed')
     },
   },
-  render: (args: CarouselArgs) => (
-    <Carousel {...args}>
-      <CarouselPrevNavigation aria-label="Previous slide">
-        <Icon icon="ArrowLeft" />
-      </CarouselPrevNavigation>
-      <CarouselSwiper />
-      <CarouselNextNavigation aria-label="Next slide">
-        <Icon icon="ArrowRight" />
-      </CarouselNextNavigation>
-    </Carousel>
-  ),
 }
 
 export default meta
 
 type Story = StoryObj<typeof Carousel>
+
+const Nav = () => (
+  <>
+    <CarouselPrevNavigation aria-label="Previous slide">
+      <Icon icon="ArrowLeft" />
+    </CarouselPrevNavigation>
+    <CarouselNextNavigation aria-label="Next slide">
+      <Icon icon="ArrowRight" />
+    </CarouselNextNavigation>
+  </>
+)
+
+const BulletPagination = () => (
+  <CarouselPagination>
+    {swiper =>
+      // eslint-disable-next-line react/no-array-index-key -- pagination bullets map 1:1 with slide positions; index is the correct identifier
+      swiper?.slides?.map((_slide, index) => <CarouselPaginationBullet key={`bullet-${index}`} index={index} />)}
+  </CarouselPagination>
+)
+
+const FractionPagination = () => (
+  <CarouselPagination>
+    <CarouselPaginationFraction />
+  </CarouselPagination>
+)
 
 export const MultipleSlidesPerView: Story = {
   name: 'Multiple slides per view',
@@ -103,6 +135,12 @@ export const MultipleSlidesPerView: Story = {
     slidesPerView: 2,
     modules: ['Navigation'],
   },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+    </Carousel>
+  ),
 }
 
 export const Autoplay: Story = {
@@ -111,6 +149,13 @@ export const Autoplay: Story = {
     modules: ['Autoplay', 'Navigation', 'Pagination'],
     autoplay: true,
   },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+      <BulletPagination />
+    </Carousel>
+  ),
 }
 
 export const FocusableContent: Story = {
@@ -158,16 +203,27 @@ export const FocusableContent: Story = {
       },
     ],
   },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+    </Carousel>
+  ),
 }
 
 export const InfiniteLooping: Story = {
   name: 'Infinite looping',
-
   args: {
     id: '4',
     loop: true,
     modules: ['Navigation'],
   },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+    </Carousel>
+  ),
 }
 
 export const PaginationBullets: Story = {
@@ -178,11 +234,36 @@ export const PaginationBullets: Story = {
   render: (args: CarouselArgs) => (
     <Carousel {...args}>
       <CarouselSwiper />
-      <CarouselPagination>
-        {swiper =>
-          // eslint-disable-next-line react/no-array-index-key -- pagination bullets map 1:1 with slide positions; index is the correct identifier
-          swiper?.slides?.map((slide, index) => <CarouselPaginationBullet key={`bullet-${index}`} index={index} />)}
-      </CarouselPagination>
+      <BulletPagination />
+    </Carousel>
+  ),
+}
+
+export const NavigationWithPaginationBullets: Story = {
+  name: 'Navigation with pagination bullets',
+  args: {
+    modules: ['Navigation', 'Pagination'],
+  },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+      <BulletPagination />
+    </Carousel>
+  ),
+}
+
+export const NavigationWithPaginationBulletsLooping: Story = {
+  name: 'Navigation with pagination bullets (looping)',
+  args: {
+    loop: true,
+    modules: ['Navigation', 'Pagination'],
+  },
+  render: (args: CarouselArgs) => (
+    <Carousel {...args}>
+      <Nav />
+      <CarouselSwiper />
+      <BulletPagination />
     </Carousel>
   ),
 }
@@ -194,16 +275,9 @@ export const PaginationFraction: Story = {
   },
   render: (args: CarouselArgs) => (
     <Carousel {...args}>
-      <CarouselPrevNavigation aria-label="Previous slide">
-        <Icon icon="ArrowLeft" />
-      </CarouselPrevNavigation>
-      <CarouselNextNavigation aria-label="Next slide">
-        <Icon icon="ArrowRight" />
-      </CarouselNextNavigation>
-      <CarouselPagination>
-        <CarouselPaginationFraction />
-      </CarouselPagination>
+      <Nav />
       <CarouselSwiper />
+      <FractionPagination />
     </Carousel>
   ),
 }
@@ -213,4 +287,9 @@ export const Legacy: Story = {
   args: {
     modules: ['Navigation'],
   },
+  render: (args: LegacyCarouselArgs) => (
+    <LegacyCarousel {...args}>
+      {slide => <>{slide.children}</>}
+    </LegacyCarousel>
+  ),
 }

--- a/libs/stack/stack-ui/src/components/Carousel/carousel.stories.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/carousel.stories.tsx
@@ -104,30 +104,36 @@ export default meta
 
 type Story = StoryObj<typeof Carousel>
 
-const Nav = () => (
-  <>
-    <CarouselPrevNavigation aria-label="Previous slide">
-      <Icon icon="ArrowLeft" />
-    </CarouselPrevNavigation>
-    <CarouselNextNavigation aria-label="Next slide">
-      <Icon icon="ArrowRight" />
-    </CarouselNextNavigation>
-  </>
-)
+function Nav() {
+  return (
+    <>
+      <CarouselPrevNavigation aria-label="Previous slide">
+        <Icon icon="ArrowLeft" />
+      </CarouselPrevNavigation>
+      <CarouselNextNavigation aria-label="Next slide">
+        <Icon icon="ArrowRight" />
+      </CarouselNextNavigation>
+    </>
+  )
+}
 
-const BulletPagination = () => (
-  <CarouselPagination>
-    {swiper =>
+function BulletPagination() {
+  return (
+    <CarouselPagination>
+      {swiper =>
       // eslint-disable-next-line react/no-array-index-key -- pagination bullets map 1:1 with slide positions; index is the correct identifier
-      swiper?.slides?.map((_slide, index) => <CarouselPaginationBullet key={`bullet-${index}`} index={index} />)}
-  </CarouselPagination>
-)
+        swiper?.slides?.map((_slide, index) => <CarouselPaginationBullet key={`bullet-${index}`} index={index} />)}
+    </CarouselPagination>
+  )
+}
 
-const FractionPagination = () => (
-  <CarouselPagination>
-    <CarouselPaginationFraction />
-  </CarouselPagination>
-)
+function FractionPagination() {
+  return (
+    <CarouselPagination>
+      <CarouselPaginationFraction />
+    </CarouselPagination>
+  )
+}
 
 export const MultipleSlidesPerView: Story = {
   name: 'Multiple slides per view',

--- a/libs/stack/stack-ui/src/components/Carousel/pagination/useCarouselPaginationBullet.tsx
+++ b/libs/stack/stack-ui/src/components/Carousel/pagination/useCarouselPaginationBullet.tsx
@@ -21,6 +21,7 @@ export function useCarouselPaginationBullet(props: TCarouselPaginationBulletProp
   const { controller, slides, swiperProps, activeIndex } = useCarousel()
   const { direction = 'horizontal' } = swiperProps
   const { index, handlePress } = props
+  const { loop } = controller?.params ?? {}
 
   const focusManager = useFocusManager()
 
@@ -40,7 +41,7 @@ export function useCarouselPaginationBullet(props: TCarouselPaginationBulletProp
 
   const { pressProps } = usePress({
     onPress: (e) => {
-      controller?.slideTo(index)
+      loop === true ? controller?.slideToLoop(index) : controller?.slideTo(index)
       handlePress?.(e)
       focusManager?.focusNext({ wrap: true })
     },

--- a/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSwiper.ts
+++ b/libs/stack/stack-ui/src/components/Carousel/swiper/useCarouselSwiper.ts
@@ -10,8 +10,6 @@ import { useCarousel } from '../../../providers/Carousel'
 
 const defaultModules: TSwiperModule[] = ['A11y', 'Controller']
 
-const paginationModule: TSwiperModule = 'Pagination'
-
 export function useCarouselSwiper(props: TCarouselSwiperProps): TCarouselSwiper {
   const { children, ...rest } = props
   const {
@@ -20,26 +18,23 @@ export function useCarouselSwiper(props: TCarouselSwiperProps): TCarouselSwiper 
     modules,
     slides,
     id,
-    nextNavigationRef,
-    prevNavigationRef,
     swiperProps: contextSwiperProps,
     swiperRef,
     setActiveIndex,
   } = useCarousel()
   const a11y = typeof controller?.params?.a11y === 'object' ? controller.params.a11y : undefined
+  const { slidesPerView, slidesPerGroup } = contextSwiperProps
 
-  const importedModules = [...(modules?.filter(module => module !== paginationModule) ?? []), ...defaultModules].map(
+  const importedModules = [...(modules ?? []), ...defaultModules].map(
     module => swiperModules[module],
   )
 
   const { containerRoleDescriptionMessage = 'carousel' } = a11y ?? {}
 
   const swiperProps: TCarouselSwiper['swiperProps'] = {
-    'navigation': {
-      nextEl: nextNavigationRef.current,
-      prevEl: prevNavigationRef.current,
-      enabled: modules?.includes('Navigation'),
-    },
+    'navigation': false,
+    'pagination': modules?.includes('Pagination') ? { el: null } : false,
+    'slidesPerGroup': slidesPerGroup ?? (typeof slidesPerView === 'number' ? slidesPerView : 1),
     id,
     'watchSlidesProgress': true,
     'role': 'group',


### PR DESCRIPTION
## Issue Link
closes #497
## Implementation details
- [ ] Updated the navigation for carousel to fix the slide skip when using the arrows and correctly using slideToLoop when the carousel has loop

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- Check the storybook stories for the carousel. 
- When using the navigation arrows, we only move the correct number of slides (depends on the number of slides per view) instead of skipping a slide each click.
- The pagination bullets use slideToLoop when the carousel has loop. Test the story with pagination bullets and looping. Go to the last slide and then swipe to come back on the first slide. The indices are reordered internally, but if you click on any bullet, you will end up on the correct slide.
- slideToLoop uses the real index compared to slideTo which uses the index.
