### PR TITLE
fix(stack-ui): wrap FocusScope children in tabIndex = -1

### DIFF
--- a/libs/stack/stack-ui/src/components/Modal/components/ModalDialog.tsx
+++ b/libs/stack/stack-ui/src/components/Modal/components/ModalDialog.tsx
@@ -11,7 +11,9 @@ function ModalDialog(props: TModalDialogProps) {
     <Dialog themeName={`${themeName}.dialog`} tokens={tokens} customTheme={customTheme} title={title} {...rest}>
       <FocusRing focusRingClass="has-focus-ring" within autoFocus>
         <FocusScope contain restoreFocus autoFocus>
-          {children}
+          <div tabIndex={-1}>
+            {children}
+          </div>
         </FocusScope>
       </FocusRing>
     </Dialog>

--- a/libs/stack/stack-ui/src/components/Popover/index.tsx
+++ b/libs/stack/stack-ui/src/components/Popover/index.tsx
@@ -68,22 +68,24 @@ export function Popover(props: TPopoverProps) {
     <Overlay>
       <Box themeName={`${themeName}.underlay`} tokens={popoverTokens} {...underlayProps} />
       <FocusScope autoFocus={autoFocus} restoreFocus={restoreFocus} contain={contain}>
-        <BoxWithForwardRef
-          themeName={`${themeName}.popover`}
-          customTheme={customTheme}
-          tokens={popoverTokens}
-          ref={popoverRef}
-          {...popoverProps}
-          tabIndex={scrollableRegionTabIndex}
-          style={style}
-        >
-          {arrow != null && cloneElement(arrow, { ...arrowProps, themeName: `${themeName}.arrow`, tokens: popoverTokens })}
-          <DismissButton onDismiss={state.close} />
-          {Children.map(children, child => (
-            <FocusRing focusRingClass="has-focus-ring">{child}</FocusRing>
-          ))}
-          <DismissButton onDismiss={state.close} />
-        </BoxWithForwardRef>
+        <div tabIndex={-1}>
+          <BoxWithForwardRef
+            themeName={`${themeName}.popover`}
+            customTheme={customTheme}
+            tokens={popoverTokens}
+            ref={popoverRef}
+            {...popoverProps}
+            tabIndex={scrollableRegionTabIndex}
+            style={style}
+          >
+            {arrow != null && cloneElement(arrow, { ...arrowProps, themeName: `${themeName}.arrow`, tokens: popoverTokens })}
+            <DismissButton onDismiss={state.close} />
+            {Children.map(children, child => (
+              <FocusRing focusRingClass="has-focus-ring">{child}</FocusRing>
+            ))}
+            <DismissButton onDismiss={state.close} />
+          </BoxWithForwardRef>
+        </div>
       </FocusScope>
     </Overlay>
   )

--- a/libs/stack/stack-ui/src/components/ShareButton/index.tsx
+++ b/libs/stack/stack-ui/src/components/ShareButton/index.tsx
@@ -141,7 +141,7 @@ export function ShareButton(props: TShareButtonProps) {
 
   return (
     <FocusScope autoFocus restoreFocus contain={isOpen}>
-      <div className={containerTheme} onKeyDown={handleKeyDown}>
+      <div tabIndex={-1} className={containerTheme} onKeyDown={handleKeyDown}>
         <ButtonWithForwardRef
           themeName={`${themeName}.button`}
           tokens={{ ...tokens, isOpen }}

--- a/libs/stack/stack-ui/src/components/fields/Select/components/Listbox.tsx
+++ b/libs/stack/stack-ui/src/components/fields/Select/components/Listbox.tsx
@@ -36,9 +36,11 @@ function InnerListBox(props: InnerListBoxProps) {
   const { children, listBoxRef, themeName, ...domSafeProps } = props
   return (
     <FocusScope autoFocus restoreFocus contain>
-      <BoxWithForwardRef {...domSafeProps} ref={listBoxRef} as="ul" themeName={`${themeName}.ul`}>
-        {children}
-      </BoxWithForwardRef>
+      <div tabIndex={-1}>
+        <BoxWithForwardRef {...domSafeProps} ref={listBoxRef} as="ul" themeName={`${themeName}.ul`}>
+          {children}
+        </BoxWithForwardRef>
+      </div>
     </FocusScope>
   )
 }


### PR DESCRIPTION
## Issue
Closes #505

## Implementation details
- [x] wrapper all children of FocusScope that are inside overlays inside a tabIndex = -1 dib

## PR Checklist      
- [ ] Lint must pass
- [ ] Build must pass
- [ ] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved focus management in Modal, Popover, ShareButton, and Listbox components to ensure proper keyboard navigation and accessibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->