### PR TITLE
fix(directus-block): mergeConfigs accepts type generic parameters

### DIFF
--- a/libs/directus/directus-block/src/utils/mergeConfigs.ts
+++ b/libs/directus/directus-block/src/utils/mergeConfigs.ts
@@ -7,15 +7,15 @@ import type { TBlockSerializerConfig } from '../components/BlockSerializer/inter
  * @param configs Array of block dispatcher serializers to merge. Later elements will always be prioritized over first elements
  * @returns Merged config
  */
-export default function mergeConfigs(
-  baseConfig: TBlockSerializerConfig,
-  ...configs: Nullable<TBlockSerializerConfig>[]
-): TBlockSerializerConfig {
-  const finalConfig = configs.reduce<TBlockSerializerConfig>((mergedConfig, config) => {
+export default function mergeConfigs<BaseConfig extends TBlockSerializerConfig = TBlockSerializerConfig, Config extends TBlockSerializerConfig = BaseConfig>(
+  baseConfig: BaseConfig,
+  ...configs: Nullable<Config>[]
+): BaseConfig {
+  const finalConfig = configs.reduce<BaseConfig>((mergedConfig, config) => {
     if (config == null)
       return mergedConfig
 
-    return { components: { ...mergedConfig.components, ...config.components } }
+    return { ...mergedConfig, components: { ...mergedConfig.components, ...config.components } }
   }, baseConfig)
 
   return finalConfig


### PR DESCRIPTION
## Issue
Closes #516

## Implementation details
- [x] mergeConfigs accepts type parameters and is generic

## PR Checklist      
- [x] Lint must pass
- [x] Build must pass
- [x] There should be no warnings/errors in the console/terminal (check locally)

## How to test this PR
- 