### PR TITLE
fix(security): add Dependabot cooldown to updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       # Group minor and patch updates to reduce PR noise
       npm-minor-patch:
@@ -26,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Adds a `cooldown` (7-day default) to each Dependabot `updates` entry (Semgrep `dependabot-missing-cooldown`). This delays version-update PRs for a week after a release, reducing exposure to malicious/broken fresh publishes. Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)